### PR TITLE
Making it easier to write test code.

### DIFF
--- a/Simple.OData.Client.Core/Adapter/AdapterFactory.cs
+++ b/Simple.OData.Client.Core/Adapter/AdapterFactory.cs
@@ -82,9 +82,11 @@ namespace Simple.OData.Client
         internal async Task<HttpResponseMessage> SendMetadataRequestAsync(CancellationToken cancellationToken)
         {
             var request = new ODataRequest(RestVerbs.Get, _session, ODataLiteral.Metadata);
-            var requestRunner = new RequestRunner(_session);
 
-            return await requestRunner.ExecuteRequestAsync(request, cancellationToken);
+            using (var requestRunner = new RequestRunner(_session))
+            {
+                return await requestRunner.ExecuteRequestAsync(request, cancellationToken);    
+            }
         }
 
         private async Task<IEnumerable<string>> GetSupportedProtocolVersionsAsync(HttpResponseMessage response)

--- a/Simple.OData.Client.Core/IODataClient.cs
+++ b/Simple.OData.Client.Core/IODataClient.cs
@@ -9,7 +9,7 @@ namespace Simple.OData.Client
     /// <summary>
     /// Provides access to OData operations.
     /// </summary>
-    public interface IODataClient
+    public interface IODataClient : IDisposable
     {
         /// <summary>
         /// Returns an instance of a fluent OData client for the specified collection.

--- a/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -109,6 +109,9 @@ namespace Simple.OData.Client
 
         private async Task ExecuteDeleteEntryAsync(FluentCommand command, CancellationToken cancellationToken)
         {
+            if (_isDisposed)
+                throw new ObjectDisposedException("Cannot access a disposed OData Client.");
+
             var collectionName = command.QualifiedEntityCollectionName;
             var entryIdent = await FormatEntryKeyAsync(command, cancellationToken);
 
@@ -132,6 +135,9 @@ namespace Simple.OData.Client
 
         private async Task ExecuteLinkEntryAsync(FluentCommand command, string linkName, IDictionary<string, object> linkedEntryKey, CancellationToken cancellationToken)
         {
+            if (_isDisposed)
+                throw new ObjectDisposedException("Cannot access a disposed OData Client.");
+
             AssertHasKey(command);
 
             var collectionName = command.QualifiedEntityCollectionName;
@@ -157,6 +163,9 @@ namespace Simple.OData.Client
 
         private async Task ExecuteUnlinkEntryAsync(FluentCommand command, string linkName, IDictionary<string, object> linkedEntryKey, CancellationToken cancellationToken)
         {
+            if (_isDisposed)
+                throw new ObjectDisposedException("Cannot access a disposed OData Client.");
+
             AssertHasKey(command);
 
             var collectionName = command.QualifiedEntityCollectionName;
@@ -212,6 +221,9 @@ namespace Simple.OData.Client
 
         private async Task ExecuteBatchActionsAsync(IList<Func<IODataClient, Task>> actions, CancellationToken cancellationToken)
         {
+            if (_isDisposed)
+                throw new ObjectDisposedException("Cannot access a disposed OData Client.");
+
             if (!actions.Any())
                 return;
 
@@ -254,6 +266,9 @@ namespace Simple.OData.Client
         private async Task<T> ExecuteRequestWithResultAsync<T>(ODataRequest request, CancellationToken cancellationToken,
             Func<ODataResponse, T> createResult, Func<T> createEmptyResult, Func<T> createBatchResult = null)
         {
+            if (_isDisposed)
+                throw new ObjectDisposedException("Cannot access a disposed OData Client.");
+
             if (IsBatchRequest)
                 return createBatchResult != null 
                     ? createBatchResult() 

--- a/Simple.OData.Client.Core/ODataClient.cs
+++ b/Simple.OData.Client.Core/ODataClient.cs
@@ -11,6 +11,7 @@ namespace Simple.OData.Client
         private readonly ODataClientSettings _settings;
         private readonly Session _session;
         private readonly RequestRunner _requestRunner;
+        private bool _isDisposed = false;
         private readonly Lazy<IBatchWriter> _lazyBatchWriter;
         private readonly ODataResponse _batchResponse;
 
@@ -19,7 +20,7 @@ namespace Simple.OData.Client
         /// </summary>
         /// <param name="urlBase">The OData service URL.</param>
         public ODataClient(string urlBase)
-            : this(new ODataClientSettings {UrlBase = urlBase})
+            : this(new ODataClientSettings { UrlBase = urlBase })
         {
         }
 
@@ -153,6 +154,12 @@ namespace Simple.OData.Client
         public void SetPluralizer(IPluralizer pluralizer)
         {
             _session.Pluralizer = pluralizer;
+        }
+
+        public void Dispose()
+        {
+            _isDisposed = true;
+            _requestRunner.Dispose();
         }
     }
 }

--- a/Simple.OData.Client.Core/ODataFeedAnnotations.cs
+++ b/Simple.OData.Client.Core/ODataFeedAnnotations.cs
@@ -45,7 +45,7 @@ namespace Simple.OData.Client
             return this.InstanceAnnotations.Select(x => (T)x);
         }
 
-        internal void CopyFrom(ODataFeedAnnotations src)
+        public void CopyFrom(ODataFeedAnnotations src)
         {
             this.Id = src.Id;
             this.Count = src.Count;

--- a/Simple.OData.Client.Core/Session.cs
+++ b/Simple.OData.Client.Core/Session.cs
@@ -105,7 +105,7 @@ namespace Simple.OData.Client
             return new Session(settings);
         }
 
-        internal static Session FromMetadata(string urlBase, string metadataString)
+        public static Session FromMetadata(string urlBase, string metadataString)
         {
             return new Session(urlBase, metadataString);
         }


### PR DESCRIPTION
By opening these two methods it is easier to write test code.
I have created an example and had to use Reflection to use these methods:
https://github.com/Fabian-Schmidt/Simple.OData.Client.Office365/tree/master/Simple.OData.Client.Office365.TDD

The idea is to speed up creating test cases by using a browser to download an example and saving it as a resource for the test project. The test project is then using the Framework to parse the files, as the live application would.

Alternative solution would be putting the access to these methods into a separate class or assembly.

Thanks,
Fabian