### PR TITLE
Add $search Functionality.

### DIFF
--- a/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
+++ b/Simple.OData.Client.Core/Adapter/CommandFormatterBase.cs
@@ -118,6 +118,9 @@ namespace Simple.OData.Client
             if (command.Details.Filter != null)
                 extraClauses.Add(string.Format("{0}={1}", ODataLiteral.Filter, Uri.EscapeDataString(command.Details.Filter)));
 
+            if (command.Details.Search != null)
+                extraClauses.Add(string.Format("{0}={1}", ODataLiteral.Search, Uri.EscapeDataString(command.Details.Search)));
+
             if (command.Details.QueryOptions != null)
                 extraClauses.Add(command.Details.QueryOptions);
 

--- a/Simple.OData.Client.Core/Fluent/CommandDetails.cs
+++ b/Simple.OData.Client.Core/Fluent/CommandDetails.cs
@@ -18,6 +18,7 @@ namespace Simple.OData.Client
         public IDictionary<string, object> EntryData { get; set; }
         public string Filter { get; set; }
         public ODataExpression FilterExpression { get; set; }
+        public string Search { get; set; }
         public int SkipCount { get; set; }
         public int TopCount { get; set; }
         public List<KeyValuePair<string, ODataExpandOptions>> ExpandAssociations { get; private set; }
@@ -63,6 +64,7 @@ namespace Simple.OData.Client
             this.EntryData = details.EntryData;
             this.Filter = details.Filter;
             this.FilterExpression = details.FilterExpression;
+            this.Search = details.Search;
             this.SkipCount = details.SkipCount;
             this.TopCount = details.TopCount;
             this.ExpandAssociations = details.ExpandAssociations;

--- a/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -130,6 +130,12 @@ namespace Simple.OData.Client
             return this as FT;
         }
 
+        public FT Search(string search)
+        {
+            this.Command.Search(search);
+            return this as FT;
+        }
+
         public FT Function(string functionName)
         {
             this.Command.Function(functionName);

--- a/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -279,6 +279,14 @@ namespace Simple.OData.Client
             return this;
         }
 
+        public FluentCommand Search(string search)
+        {
+            if (IsBatchResponse) return this;
+
+            _details.Search = search;
+            return this;
+        }
+
         public FluentCommand Skip(int count)
         {
             if (IsBatchResponse) return this;
@@ -571,6 +579,11 @@ namespace Simple.OData.Client
         internal bool HasFilter
         {
             get { return !string.IsNullOrEmpty(_details.Filter) || !ReferenceEquals(_details.FilterExpression, null); }
+        }
+
+        internal bool HasSearch
+        {
+            get { return !string.IsNullOrEmpty(_details.Search); }
         }
 
         public bool HasFunction

--- a/Simple.OData.Client.Core/Fluent/IFluentClient.cs
+++ b/Simple.OData.Client.Core/Fluent/IFluentClient.cs
@@ -90,6 +90,13 @@ namespace Simple.OData.Client
         FT Filter(Expression<Func<T, bool>> expression);
 
         /// <summary>
+        /// Sets the specified OData search.
+        /// </summary>
+        /// <param name="search">The search term.</param>
+        /// <returns>Self.</returns>
+        FT Search(string search);
+
+        /// <summary>
         /// Sets the OData function name.
         /// </summary>
         /// <param name="functionName">Name of the function.</param>

--- a/Simple.OData.Client.Core/ODataLiteral.cs
+++ b/Simple.OData.Client.Core/ODataLiteral.cs
@@ -4,6 +4,7 @@
     {
         public const string Metadata = "$metadata";
         public const string Filter = "$filter";
+        public const string Search = "$search";
         public const string Skip = "$skip";
         public const string Top = "$top";
         public const string Expand = "$expand";


### PR DESCRIPTION
Difficult to write tests for this as the Northwind solution hasn't been updated to support $search. However we are using ElasticSearch as our data store and have been able to implement $search support ourselves.

It would be very useful to be able to use search in your client.

Any suggestions on the proposed request? I thought you may have a set of tests which check the urls produced?

Thanks,

Jon