### PR TITLE
Fixes regression from 4.11 to 4.12+ with Utils.TryConvert and Nullables

### DIFF
--- a/Simple.OData.Client.Core/Utils.cs
+++ b/Simple.OData.Client.Core/Utils.cs
@@ -152,6 +152,10 @@ namespace Simple.OData.Client
                 {
                     result = Enum.ToObject(targetType, value);
                 }
+                else if (Nullable.GetUnderlyingType(targetType) == value.GetType())
+                {
+                    result = value;
+                }
                 else
                 {
                     result = System.Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);


### PR DESCRIPTION
As detailed in #192 when `Utils.TryConvert` attempts to coerce a non-nullable value type to a nullable it falls back on calling `System.Convert.ChangeType`, which fails to perform this coercion. This patch (on the v4 branch, lands cleanly in master but I've not tested there) adds a test using `Nullable.GetUnderlyingType` before the fallback `Convert.ChangeType`, which resolves this regression.