### PR TITLE
support custom feed annotations

### DIFF
--- a/Simple.OData.Client.V4.Adapter/ResponseReader.cs
+++ b/Simple.OData.Client.V4.Adapter/ResponseReader.cs
@@ -78,6 +78,7 @@ namespace Simple.OData.Client.V4.Adapter
         {
             var readerSettings = new ODataMessageReaderSettings();
             readerSettings.MessageQuotas.MaxReceivedMessageSize = Int32.MaxValue;
+            readerSettings.ShouldIncludeAnnotation = x => _session.Settings.IncludeAnnotationsInResults;
             using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model))
             {
                 var payloadKind = messageReader.DetectPayloadKind();


### PR DESCRIPTION
only standard odata annotations are returned by default. If custom annotations are used, these are only returned by the Reader if ShouldIncludeAnnotation returns true.