### PR TITLE
Use ConfigureAwait(false) on all awaiting tasks

### DIFF
--- a/Simple.OData.Client.Core/Adapter/AdapterFactory.cs
+++ b/Simple.OData.Client.Core/Adapter/AdapterFactory.cs
@@ -26,7 +26,7 @@ namespace Simple.OData.Client
 
         public async Task<IODataAdapter> CreateAdapterAsync(HttpResponseMessage response)
         {
-            var protocolVersions = (await GetSupportedProtocolVersionsAsync(response)).ToArray();
+            var protocolVersions = (await GetSupportedProtocolVersionsAsync(response).ConfigureAwait(false)).ToArray();
 
             foreach (var protocolVersion in protocolVersions)
             {
@@ -49,7 +49,7 @@ namespace Simple.OData.Client
 
         public async Task<string> GetMetadataDocumentAsync(HttpResponseMessage response)
         {
-            return await response.Content.ReadAsStringAsync();
+            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
 
         public IODataAdapter ParseMetadata(string metadataDocument)
@@ -98,7 +98,7 @@ namespace Simple.OData.Client
             {
                 try
                 {
-                    var metadataString = await GetMetadataDocumentAsync(response);
+                    var metadataString = await GetMetadataDocumentAsync(response).ConfigureAwait(false);
                     var protocolVersion = GetMetadataProtocolVersion(metadataString);
                     return new[] { protocolVersion };
                 }

--- a/Simple.OData.Client.Core/Adapter/BatchWriterBase.cs
+++ b/Simple.OData.Client.Core/Adapter/BatchWriterBase.cs
@@ -33,7 +33,7 @@ namespace Simple.OData.Client
             var lastOperationId = 0;
             foreach (var action in actions)
             {
-                await action(client);
+                await action(client).ConfigureAwait(false);
                 var responseIndex = -1;
                 if (this.LastOperationId > lastOperationId)
                 {
@@ -46,7 +46,7 @@ namespace Simple.OData.Client
             if (this.HasOperations)
             {
                 // Create batch request message
-                var requestMessage = await EndBatchAsync();
+                var requestMessage = await EndBatchAsync().ConfigureAwait(false);
                 return new ODataRequest(RestVerbs.Post, _session, ODataLiteral.Batch, requestMessage);
             }
             else
@@ -92,12 +92,12 @@ namespace Simple.OData.Client
         {
             if (method != RestVerbs.Get && !_pendingChangeSet)
             {
-                await StartChangesetAsync();
+                await StartChangesetAsync().ConfigureAwait(false);
                 _pendingChangeSet = true;
             }
             else if (method == RestVerbs.Get && _pendingChangeSet)
             {
-                await EndChangesetAsync();
+                await EndChangesetAsync().ConfigureAwait(false);
                 _pendingChangeSet = false;
             }
 
@@ -107,7 +107,7 @@ namespace Simple.OData.Client
                 MapContentId(entryData, contentId);
             }
 
-            return await CreateOperationMessageAsync(uri, method, collection, contentId, resultRequired);
+            return await CreateOperationMessageAsync(uri, method, collection, contentId, resultRequired).ConfigureAwait(false);
         }
 
         public bool HasOperations { get; protected set; }

--- a/Simple.OData.Client.Core/Adapter/RequestWriterBase.cs
+++ b/Simple.OData.Client.Core/Adapter/RequestWriterBase.cs
@@ -28,7 +28,7 @@ namespace Simple.OData.Client
         public async Task<ODataRequest> CreateGetRequestAsync(string commandText, bool scalarResult)
         {
             await WriteEntryContentAsync(
-                RestVerbs.Get, Utils.ExtractCollectionName(commandText), commandText, null, true);
+                RestVerbs.Get, Utils.ExtractCollectionName(commandText), commandText, null, true).ConfigureAwait(false);
 
             var request = new ODataRequest(RestVerbs.Get, _session, commandText)
             {
@@ -49,7 +49,7 @@ namespace Simple.OData.Client
             }
 
             var entryContent = await WriteEntryContentAsync(
-                RestVerbs.Post, collection, commandText, entryData, resultRequired);
+                RestVerbs.Post, collection, commandText, entryData, resultRequired).ConfigureAwait(false);
 
             var request = new ODataRequest(RestVerbs.Post, _session, commandText, entryData, entryContent)
             {
@@ -70,7 +70,7 @@ namespace Simple.OData.Client
                 usePatch = false;
 
             var entryContent = await WriteEntryContentAsync(
-                usePatch ? RestVerbs.Patch : RestVerbs.Put, collection, entryIdent, entryData, resultRequired);
+                usePatch ? RestVerbs.Patch : RestVerbs.Put, collection, entryIdent, entryData, resultRequired).ConfigureAwait(false);
 
             var updateMethod = usePatch ? RestVerbs.Patch : RestVerbs.Put;
             var checkOptimisticConcurrency = _session.Metadata.EntityCollectionRequiresOptimisticConcurrencyCheck(collection);
@@ -86,7 +86,7 @@ namespace Simple.OData.Client
         public async Task<ODataRequest> CreateDeleteRequestAsync(string collection, string entryIdent)
         {
             await WriteEntryContentAsync(
-                RestVerbs.Delete, collection, entryIdent, null, false);
+                RestVerbs.Delete, collection, entryIdent, null, false).ConfigureAwait(false);
 
             var request = new ODataRequest(RestVerbs.Delete, _session, entryIdent)
             {
@@ -104,7 +104,7 @@ namespace Simple.OData.Client
                 RestVerbs.Put;
 
             var commandText = FormatLinkPath(entryIdent, associationName);
-            var linkContent = await WriteLinkContentAsync(linkMethod, commandText, linkIdent);
+            var linkContent = await WriteLinkContentAsync(linkMethod, commandText, linkIdent).ConfigureAwait(false);
             var request = new ODataRequest(linkMethod, _session, commandText, null, linkContent)
             {
                 IsLink = true,
@@ -116,7 +116,7 @@ namespace Simple.OData.Client
         public async Task<ODataRequest> CreateUnlinkRequestAsync(string collection, string linkName, string entryIdent, string linkIdent)
         {
             var associationName = _session.Metadata.GetNavigationPropertyExactName(collection, linkName);
-            await WriteEntryContentAsync(RestVerbs.Delete, collection, entryIdent, null, false);
+            await WriteEntryContentAsync(RestVerbs.Delete, collection, entryIdent, null, false).ConfigureAwait(false);
 
             var commandText = FormatLinkPath(entryIdent, associationName, linkIdent);
             var request = new ODataRequest(RestVerbs.Delete, _session, commandText)
@@ -131,7 +131,7 @@ namespace Simple.OData.Client
         {
             var verb = _session.Metadata.GetFunctionVerb(functionName);
 
-            await WriteFunctionContentAsync(verb, commandText);
+            await WriteFunctionContentAsync(verb, commandText).ConfigureAwait(false);
 
             var request = new ODataRequest(verb, _session, commandText)
             {
@@ -148,11 +148,11 @@ namespace Simple.OData.Client
 
             if (parameters != null && parameters.Any())
             {
-                entryContent = await WriteActionContentAsync(RestVerbs.Post, commandText, actionName, parameters);
+                entryContent = await WriteActionContentAsync(RestVerbs.Post, commandText, actionName, parameters).ConfigureAwait(false);
             }
             else
             {
-                await WriteFunctionContentAsync(verb, commandText);
+                await WriteFunctionContentAsync(verb, commandText).ConfigureAwait(false);
             }
 
             var request = new ODataRequest(verb, _session, commandText, parameters, entryContent)

--- a/Simple.OData.Client.Core/Adapter/ResponseReaderBase.cs
+++ b/Simple.OData.Client.Core/Adapter/ResponseReaderBase.cs
@@ -40,7 +40,7 @@ namespace Simple.OData.Client
                     }
                     else
                     {
-                        await actions[actionIndex](new ODataClient(client as ODataClient, actionResponse));
+                        await actions[actionIndex](new ODataClient(client as ODataClient, actionResponse)).ConfigureAwait(false);
                     }
                 }
             }

--- a/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
+++ b/Simple.OData.Client.Core/Fluent/BoundClient.Async.cs
@@ -44,13 +44,13 @@ namespace Simple.OData.Client
 
         public async Task<IEnumerable<T>> FindEntriesAsync(ODataFeedAnnotations annotations, CancellationToken cancellationToken)
         {
-            var commandText = await _command.WithCount().GetCommandTextAsync(cancellationToken);
+            var commandText = await _command.WithCount().GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested)
                 cancellationToken.ThrowIfCancellationRequested();
 
             var result = _client.FindEntriesAsync(commandText, annotations, cancellationToken);
             return await RectifyColumnSelectionAsync(
-                result, _command.SelectedColumns, _command.DynamicPropertiesContainerName);
+                result, _command.SelectedColumns, _command.DynamicPropertiesContainerName).ConfigureAwait(false);
         }
 
         public Task<IEnumerable<T>> FindEntriesAsync(Uri annotatedUri, ODataFeedAnnotations annotations)
@@ -66,7 +66,7 @@ namespace Simple.OData.Client
 
             var result = _client.FindEntriesAsync(commandText, annotations, cancellationToken);
             return await RectifyColumnSelectionAsync(
-                result, _command.SelectedColumns, _command.DynamicPropertiesContainerName);
+                result, _command.SelectedColumns, _command.DynamicPropertiesContainerName).ConfigureAwait(false);
         }
 
         public Task<T> FindEntryAsync()
@@ -88,7 +88,7 @@ namespace Simple.OData.Client
 
         public async Task<U> FindScalarAsync<U>(CancellationToken cancellationToken)
         {
-            var result = await _client.FindScalarAsync(_command, cancellationToken);
+            var result = await _client.FindScalarAsync(_command, cancellationToken).ConfigureAwait(false);
             return _client.IsBatchRequest 
                 ? default(U) 
                 : (U)Utils.Convert(result, typeof(U));
@@ -111,7 +111,7 @@ namespace Simple.OData.Client
 
         public async Task<T> InsertEntryAsync(bool resultRequired, CancellationToken cancellationToken)
         {
-            var result = await _client.InsertEntryAsync(_command, _command.CommandData, resultRequired, cancellationToken);
+            var result = await _client.InsertEntryAsync(_command, _command.CommandData, resultRequired, cancellationToken).ConfigureAwait(false);
             return result.ToObject<T>(_command.DynamicPropertiesContainerName, _dynamicResults);
         }
 
@@ -134,14 +134,14 @@ namespace Simple.OData.Client
         {
             if (_command.HasFilter)
             {
-                var result = await UpdateEntriesAsync(resultRequired, cancellationToken);
+                var result = await UpdateEntriesAsync(resultRequired, cancellationToken).ConfigureAwait(false);
                 return resultRequired 
                     ? result == null ? null : result.First()
                     : null;
             }
             else
             {
-                var result = await _client.UpdateEntryAsync(_command, resultRequired, cancellationToken);
+                var result = await _client.UpdateEntryAsync(_command, resultRequired, cancellationToken).ConfigureAwait(false);
                 return resultRequired
                     ? result == null ? null : result.ToObject<T>(_command.DynamicPropertiesContainerName, _dynamicResults)
                     : null;
@@ -165,7 +165,7 @@ namespace Simple.OData.Client
 
         public async Task<IEnumerable<T>> UpdateEntriesAsync(bool resultRequired, CancellationToken cancellationToken)
         {
-            var result = await _client.UpdateEntriesAsync(_command, _command.CommandData, resultRequired, cancellationToken);
+            var result = await _client.UpdateEntriesAsync(_command, _command.CommandData, resultRequired, cancellationToken).ConfigureAwait(false);
             return result.Select(y => y.ToObject<T>(_command.DynamicPropertiesContainerName, _dynamicResults));
         }
 

--- a/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -292,20 +292,20 @@ namespace Simple.OData.Client
         protected async Task<IEnumerable<T>> RectifyColumnSelectionAsync(
             Task<IEnumerable<IDictionary<string, object>>> entries, IList<string> selectedColumns, string dynamicPropertiesContainerName)
         {
-            var result = RectifyColumnSelection(await entries, selectedColumns);
+            var result = RectifyColumnSelection(await entries.ConfigureAwait(false), selectedColumns);
             return result == null ? null : result.Select(z => ConvertResult(z, dynamicPropertiesContainerName));
         }
 
         protected async Task<T> RectifyColumnSelectionAsync(
             Task<IDictionary<string, object>> entry, IList<string> selectedColumns, string dynamicPropertiesContainerName)
         {
-            return ConvertResult(RectifyColumnSelection(await entry, selectedColumns), dynamicPropertiesContainerName);
+            return ConvertResult(RectifyColumnSelection(await entry.ConfigureAwait(false), selectedColumns), dynamicPropertiesContainerName);
         }
 
         protected async Task<Tuple<IEnumerable<T>, int>> RectifyColumnSelectionAsync(
             Task<Tuple<IEnumerable<IDictionary<string, object>>, int>> entries, IList<string> selectedColumns, string dynamicPropertiesContainerName)
         {
-            var result = await entries;
+            var result = await entries.ConfigureAwait(false);
             return new Tuple<IEnumerable<T>, int>(
                 RectifyColumnSelection(result.Item1, selectedColumns).Select(y => ConvertResult(y, dynamicPropertiesContainerName)),
                 result.Item2);

--- a/Simple.OData.Client.Core/Fluent/FluentCommand.cs
+++ b/Simple.OData.Client.Core/Fluent/FluentCommand.cs
@@ -132,7 +132,7 @@ namespace Simple.OData.Client
 
         public async Task<string> GetCommandTextAsync(CancellationToken cancellationToken)
         {
-            await _details.Session.ResolveAdapterAsync(cancellationToken);
+            await _details.Session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             return new FluentCommand(this).Resolve().Format();
         }
 

--- a/Simple.OData.Client.Core/Http/RequestRunner.cs
+++ b/Simple.OData.Client.Core/Http/RequestRunner.cs
@@ -32,21 +32,21 @@ namespace Simple.OData.Client
                 _session.Trace("{0} request: {1}", request.Method, request.RequestMessage.RequestUri.AbsoluteUri);
                 if (request.RequestMessage.Content != null && (_session.Settings.TraceFilter & ODataTrace.RequestContent) != 0)
                 {
-                    var content = await request.RequestMessage.Content.ReadAsStringAsync();
+                    var content = await request.RequestMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
                     _session.Trace("Request content:{0}{1}", Environment.NewLine, content);
                 }
 
-                var response = await httpConnection.HttpClient.SendAsync(request.RequestMessage, cancellationToken);
+                var response = await httpConnection.HttpClient.SendAsync(request.RequestMessage, cancellationToken).ConfigureAwait(false);
                 if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
                 _session.Trace("Request completed: {0}", response.StatusCode);
                 if (response.Content != null && (_session.Settings.TraceFilter & ODataTrace.ResponseContent) != 0)
                 {
-                    var content = await response.Content.ReadAsStringAsync();
+                    var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                     _session.Trace("Response content:{0}{1}", Environment.NewLine, content);
                 }
 
-                await PostExecute(response);
+                await PostExecute(response).ConfigureAwait(false);
                 return response;
             }
             catch (WebException ex)
@@ -107,7 +107,7 @@ namespace Simple.OData.Client
 
             if (!responseMessage.IsSuccessStatusCode)
             {
-                throw await WebRequestException.CreateFromResponseMessageAsync(responseMessage);
+                throw await WebRequestException.CreateFromResponseMessageAsync(responseMessage).ConfigureAwait(false);
             }
         }
     }

--- a/Simple.OData.Client.Core/Http/WebRequestException.cs
+++ b/Simple.OData.Client.Core/Http/WebRequestException.cs
@@ -27,7 +27,7 @@ namespace Simple.OData.Client
         {
             var requestUri = response.RequestMessage != null ? response.RequestMessage.RequestUri : null;
             return new WebRequestException(response.ReasonPhrase, response.StatusCode, requestUri,
-                response.Content != null ? await response.Content.ReadAsStringAsync() : null, null);
+                response.Content != null ? await response.Content.ReadAsStringAsync().ConfigureAwait(false) : null, null);
         }
 
         /// <summary>

--- a/Simple.OData.Client.Core/ODataClient.Async.cs
+++ b/Simple.OData.Client.Core/ODataClient.Async.cs
@@ -194,7 +194,7 @@ namespace Simple.OData.Client
         public static async Task<T> GetMetadataAsync<T>(string urlBase, ICredentials credentials, CancellationToken cancellationToken)
         {
             var session = Session.FromSettings(new ODataClientSettings(urlBase, credentials));
-            await session.ResolveAdapterAsync(cancellationToken);
+            await session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             return (T)session.Adapter.Model;
         }
 
@@ -211,7 +211,7 @@ namespace Simple.OData.Client
         public static async Task<T> GetMetadataAsync<T>(Uri baseUri, ICredentials credentials, CancellationToken cancellationToken)
         {
             var session = Session.FromSettings(new ODataClientSettings(baseUri, credentials));
-            await session.ResolveAdapterAsync(cancellationToken);
+            await session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             return (T)session.Adapter.Model;
         }
 
@@ -293,7 +293,7 @@ namespace Simple.OData.Client
         public static async Task<string> GetMetadataAsStringAsync(string urlBase, ICredentials credentials, CancellationToken cancellationToken)
         {
             var session = Session.FromSettings(new ODataClientSettings(urlBase, credentials));
-            await session.ResolveAdapterAsync(cancellationToken);
+            await session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             return session.MetadataCache.MetadataDocument;
         }
 
@@ -307,7 +307,7 @@ namespace Simple.OData.Client
         public static async Task<string> GetMetadataDocumentAsync(Uri baseUri, ICredentials credentials, CancellationToken cancellationToken)
         {
             var session = Session.FromSettings(new ODataClientSettings(baseUri, credentials));
-            await session.ResolveAdapterAsync(cancellationToken);
+            await session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             return session.MetadataCache.MetadataDocument;
         }
 
@@ -315,28 +315,28 @@ namespace Simple.OData.Client
 
         internal async Task<Session> GetSessionAsync()
         {
-            await _session.ResolveAdapterAsync(CancellationToken.None);
+            await _session.ResolveAdapterAsync(CancellationToken.None).ConfigureAwait(false);
             return _session;
         }
 
         public async Task<object> GetMetadataAsync()
         {
-            return (await _session.ResolveAdapterAsync(CancellationToken.None)).Model;
+            return (await _session.ResolveAdapterAsync(CancellationToken.None).ConfigureAwait(false)).Model;
         }
 
         public async Task<object> GetMetadataAsync(CancellationToken cancellationToken)
         {
-            return (await _session.ResolveAdapterAsync(cancellationToken)).Model;
+            return (await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false)).Model;
         }
 
         public async Task<T> GetMetadataAsync<T>()
         {
-            return (T)(await _session.ResolveAdapterAsync(CancellationToken.None)).Model;
+            return (T)(await _session.ResolveAdapterAsync(CancellationToken.None).ConfigureAwait(false)).Model;
         }
 
         public async Task<T> GetMetadataAsync<T>(CancellationToken cancellationToken)
         {
-            return (T)(await _session.ResolveAdapterAsync(cancellationToken)).Model;
+            return (T)(await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false)).Model;
         }
 
         public Task<string> GetMetadataAsStringAsync()
@@ -351,13 +351,13 @@ namespace Simple.OData.Client
 
         public async Task<string> GetMetadataAsStringAsync(CancellationToken cancellationToken)
         {
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             return _session.MetadataCache.MetadataDocument;
         }
 
         public async Task<string> GetMetadataDocumentAsync(CancellationToken cancellationToken)
         {
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             return _session.MetadataCache.MetadataDocument;
         }
 
@@ -368,13 +368,14 @@ namespace Simple.OData.Client
 
         public async Task<string> GetCommandTextAsync(string collection, ODataExpression expression, CancellationToken cancellationToken)
         {
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await GetFluentClient()
                 .For(collection)
                 .Filter(expression)
-                .GetCommandTextAsync(cancellationToken);
+                .GetCommandTextAsync(cancellationToken)
+                .ConfigureAwait(false);
         }
 
         public Task<string> GetCommandTextAsync<T>(string collection, Expression<Func<T, bool>> expression)
@@ -384,13 +385,14 @@ namespace Simple.OData.Client
 
         public async Task<string> GetCommandTextAsync<T>(string collection, Expression<Func<T, bool>> expression, CancellationToken cancellationToken)
         {
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             return await GetFluentClient()
                 .For(collection)
                 .Filter(ODataExpression.FromLinqExpression(expression.Body))
-                .GetCommandTextAsync(cancellationToken);
+                .GetCommandTextAsync(cancellationToken)
+                .ConfigureAwait(false);
         }
 
         public Task<IEnumerable<IDictionary<string, object>>> FindEntriesAsync(string commandText)
@@ -433,15 +435,15 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateGetRequestAsync(commandText, false);
+                .CreateGetRequestAsync(commandText, false).ConfigureAwait(false);
 
             var result = await ExecuteRequestWithResultAsync(request, cancellationToken,
                 x => x.AsEntries(),
-                () => new IDictionary<string, object>[] {});
+                () => new IDictionary<string, object>[] { }).ConfigureAwait(false);
             return result == null ? null : result.FirstOrDefault();
         }
 
@@ -455,15 +457,15 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsScalar<object>();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateGetRequestAsync(commandText, true);
+                .CreateGetRequestAsync(commandText, true).ConfigureAwait(false);
 
             var result = await ExecuteRequestWithResultAsync(request, cancellationToken,
                 x => x.AsEntries(),
-                () => new IDictionary<string, object>[] {});
+                () => new IDictionary<string, object>[] { }).ConfigureAwait(false);
 
             Func<IDictionary<string, object>, object> extractScalar = x => (x == null) || !x.Any() ? null : x.Values.First();
             return result == null ? null : extractScalar(result.FirstOrDefault());
@@ -479,7 +481,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var entryKeyWithNames = new Dictionary<string, object>();
@@ -489,7 +491,7 @@ namespace Simple.OData.Client
             {
                 entryKeyWithNames.Add(keyNames[index], entryKey.ElementAt(index));
             }
-            return await GetEntryAsync(collection, entryKeyWithNames, cancellationToken);
+            return await GetEntryAsync(collection, entryKeyWithNames, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<IDictionary<string, object>> GetEntryAsync(string collection, IDictionary<string, object> entryKey)
@@ -502,16 +504,16 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var entryIdent = await FormatEntryKeyAsync(collection, entryKey, cancellationToken);
+            var entryIdent = await FormatEntryKeyAsync(collection, entryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateGetRequestAsync(entryIdent, false);
+                .CreateGetRequestAsync(entryIdent, false).ConfigureAwait(false);
 
-            return await ExecuteRequestWithResultAsync(request, cancellationToken, x => x.AsEntry(), () => null);
+            return await ExecuteRequestWithResultAsync(request, cancellationToken, x => x.AsEntry(), () => null).ConfigureAwait(false);
         }
 
         public Task<IDictionary<string, object>> InsertEntryAsync(string collection, IDictionary<string, object> entryData)
@@ -534,7 +536,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             RemoveSystemProperties(entryData);
@@ -544,7 +546,7 @@ namespace Simple.OData.Client
                 .Set(entryData)
                 .AsBoundClient().Command;
 
-            return await ExecuteInsertEntryAsync(command, resultRequired, cancellationToken);
+            return await ExecuteInsertEntryAsync(command, resultRequired, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<IDictionary<string, object>> UpdateEntryAsync(string collection, IDictionary<string, object> entryKey, IDictionary<string, object> entryData)
@@ -567,7 +569,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             RemoveSystemProperties(entryKey);
@@ -579,7 +581,7 @@ namespace Simple.OData.Client
                 .Set(entryData)
                 .AsBoundClient().Command;
 
-            return await ExecuteUpdateEntryAsync(command, resultRequired, cancellationToken);
+            return await ExecuteUpdateEntryAsync(command, resultRequired, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<IEnumerable<IDictionary<string, object>>> UpdateEntriesAsync(string collection, string commandText, IDictionary<string, object> entryData)
@@ -602,7 +604,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntries();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             RemoveSystemProperties(entryData);
@@ -613,7 +615,7 @@ namespace Simple.OData.Client
                 .Set(entryData)
                 .AsBoundClient().Command;
 
-            return await ExecuteUpdateEntriesAsync(command, resultRequired, cancellationToken);
+            return await ExecuteUpdateEntriesAsync(command, resultRequired, cancellationToken).ConfigureAwait(false);
         }
 
         public Task DeleteEntryAsync(string collection, IDictionary<string, object> entryKey)
@@ -626,7 +628,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             RemoveSystemProperties(entryKey);
@@ -636,7 +638,7 @@ namespace Simple.OData.Client
                 .Key(entryKey)
                 .AsBoundClient().Command;
 
-            await ExecuteDeleteEntryAsync(command, cancellationToken);
+            await ExecuteDeleteEntryAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<int> DeleteEntriesAsync(string collection, string commandText)
@@ -649,7 +651,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return 0;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var command = GetFluentClient()
@@ -657,7 +659,7 @@ namespace Simple.OData.Client
                 .Filter(ExtractFilterFromCommandText(collection, commandText))
                 .AsBoundClient().Command;
 
-            return await ExecuteDeleteEntriesAsync(command, cancellationToken);
+            return await ExecuteDeleteEntriesAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
         public Task LinkEntryAsync(string collection, IDictionary<string, object> entryKey, string linkName, IDictionary<string, object> linkedEntryKey)
@@ -670,7 +672,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             RemoveSystemProperties(entryKey);
@@ -681,7 +683,7 @@ namespace Simple.OData.Client
                 .Key(entryKey)
                 .AsBoundClient().Command;
 
-            await ExecuteLinkEntryAsync(command, linkName, linkedEntryKey, cancellationToken);
+            await ExecuteLinkEntryAsync(command, linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
         }
 
         public Task UnlinkEntryAsync(string collection, IDictionary<string, object> entryKey, string linkName)
@@ -704,7 +706,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             RemoveSystemProperties(entryKey);
@@ -714,7 +716,7 @@ namespace Simple.OData.Client
                 .Key(entryKey)
                 .AsBoundClient().Command;
 
-            await ExecuteUnlinkEntryAsync(command, linkName, linkedEntryKey, cancellationToken);
+            await ExecuteUnlinkEntryAsync(command, linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<IDictionary<string, object>> ExecuteFunctionAsSingleAsync(string functionName, IDictionary<string, object> parameters)
@@ -727,7 +729,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var command = GetFluentClient()
@@ -735,7 +737,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            var result = await ExecuteFunctionAsync(command, cancellationToken);
+            var result = await ExecuteFunctionAsync(command, cancellationToken).ConfigureAwait(false);
             return result == null ? null : result.FirstOrDefault();
         }
 
@@ -749,7 +751,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntries();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var command = GetFluentClient()
@@ -757,7 +759,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            return await ExecuteFunctionAsync(command, cancellationToken);
+            return await ExecuteFunctionAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<T> ExecuteFunctionAsScalarAsync<T>(string functionName, IDictionary<string, object> parameters)
@@ -770,10 +772,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsScalar<T>();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var result = await ExecuteFunctionAsSingleAsync(functionName, parameters, cancellationToken);
+            var result = await ExecuteFunctionAsSingleAsync(functionName, parameters, cancellationToken).ConfigureAwait(false);
             return (T)result.First().Value;
         }
 
@@ -787,10 +789,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsArray<T>();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var result = await ExecuteFunctionAsEnumerableAsync(functionName, parameters, cancellationToken);
+            var result = await ExecuteFunctionAsEnumerableAsync(functionName, parameters, cancellationToken).ConfigureAwait(false);
             return IsBatchRequest
                 ? new T[] {}
                 : result == null
@@ -810,7 +812,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var command = GetFluentClient()
@@ -818,7 +820,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            await ExecuteActionAsync(command, cancellationToken);
+            await ExecuteActionAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<IDictionary<string, object>> ExecuteActionAsSingleAsync(string actionName, IDictionary<string, object> parameters)
@@ -831,7 +833,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var command = GetFluentClient()
@@ -839,7 +841,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            var result = await ExecuteActionAsync(command, cancellationToken);
+            var result = await ExecuteActionAsync(command, cancellationToken).ConfigureAwait(false);
             return result == null ? null : result.FirstOrDefault();
         }
 
@@ -853,7 +855,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntries();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var command = GetFluentClient()
@@ -861,7 +863,7 @@ namespace Simple.OData.Client
                 .Set(parameters)
                 .AsBoundClient().Command;
 
-            return await ExecuteActionAsync(command, cancellationToken);
+            return await ExecuteActionAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
         public Task<T> ExecuteActionAsScalarAsync<T>(string actionName, IDictionary<string, object> parameters)
@@ -874,10 +876,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsScalar<T>();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var result = await ExecuteActionAsSingleAsync(actionName, parameters, cancellationToken);
+            var result = await ExecuteActionAsSingleAsync(actionName, parameters, cancellationToken).ConfigureAwait(false);
             return (T)result.First().Value;
         }
 
@@ -891,10 +893,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsArray<T>();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var result = await ExecuteActionAsEnumerableAsync(actionName, parameters, cancellationToken);
+            var result = await ExecuteActionAsEnumerableAsync(actionName, parameters, cancellationToken).ConfigureAwait(false);
             return IsBatchRequest
                 ? new T[] { }
                 : result == null
@@ -915,11 +917,11 @@ namespace Simple.OData.Client
                 return _batchResponse.AsEntries();
             }
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateGetRequestAsync(commandText, scalarResult);
+                .CreateGetRequestAsync(commandText, scalarResult).ConfigureAwait(false);
 
             return await ExecuteRequestWithResultAsync(request, cancellationToken, x =>
             {
@@ -927,7 +929,7 @@ namespace Simple.OData.Client
                     annotations.CopyFrom(x.Annotations);
                 return x.AsEntries();
             },
-            () => new IDictionary<string, object>[] { });
+            () => new IDictionary<string, object>[] { }).ConfigureAwait(false);
         }
 
         internal async Task<IEnumerable<IDictionary<string, object>>> FindEntriesAsync(FluentCommand command, CancellationToken cancellationToken)
@@ -935,13 +937,13 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntries();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await FindEntriesAsync(commandText, cancellationToken);
+            return await FindEntriesAsync(commandText, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IEnumerable<IDictionary<string, object>>> FindEntriesAsync(FluentCommand command, bool scalarResult, CancellationToken cancellationToken)
@@ -949,13 +951,13 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntries();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await FindEntriesAsync(commandText, scalarResult, cancellationToken);
+            return await FindEntriesAsync(commandText, scalarResult, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IEnumerable<IDictionary<string, object>>> FindEntriesAsync(FluentCommand command, ODataFeedAnnotations annotations, CancellationToken cancellationToken)
@@ -966,13 +968,13 @@ namespace Simple.OData.Client
                 return _batchResponse.AsEntries();
             }
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await FindEntriesAsync(commandText, annotations, cancellationToken);
+            return await FindEntriesAsync(commandText, annotations, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IDictionary<string, object>> FindEntryAsync(FluentCommand command, CancellationToken cancellationToken)
@@ -980,13 +982,13 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await FindEntryAsync(commandText, cancellationToken);
+            return await FindEntryAsync(commandText, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<object> FindScalarAsync(FluentCommand command, CancellationToken cancellationToken)
@@ -994,13 +996,13 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsScalar<object>();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await FindScalarAsync(commandText, cancellationToken);
+            return await FindScalarAsync(commandText, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IDictionary<string, object>> InsertEntryAsync(FluentCommand command, IDictionary<string, object> entryData, bool resultRequired, CancellationToken cancellationToken)
@@ -1008,10 +1010,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await ExecuteInsertEntryAsync(new FluentCommand(command).Set(entryData), resultRequired, cancellationToken);
+            return await ExecuteInsertEntryAsync(new FluentCommand(command).Set(entryData), resultRequired, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IDictionary<string, object>> UpdateEntryAsync(FluentCommand command, bool resultRequired, CancellationToken cancellationToken)
@@ -1019,10 +1021,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await ExecuteUpdateEntryAsync(command, resultRequired, cancellationToken);
+            return await ExecuteUpdateEntryAsync(command, resultRequired, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IEnumerable<IDictionary<string, object>>> UpdateEntriesAsync(FluentCommand command, IDictionary<string, object> entryData, bool resultRequired, CancellationToken cancellationToken)
@@ -1030,10 +1032,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntries();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await ExecuteUpdateEntriesAsync(command, resultRequired, cancellationToken);
+            return await ExecuteUpdateEntriesAsync(command, resultRequired, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task DeleteEntryAsync(FluentCommand command, CancellationToken cancellationToken)
@@ -1041,10 +1043,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            await ExecuteDeleteEntryAsync(command, cancellationToken);
+            await ExecuteDeleteEntryAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<int> DeleteEntriesAsync(FluentCommand command, CancellationToken cancellationToken)
@@ -1052,10 +1054,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return 0;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            return await ExecuteDeleteEntriesAsync(command, cancellationToken);
+            return await ExecuteDeleteEntriesAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task LinkEntryAsync(FluentCommand command, string linkName, IDictionary<string, object> linkedEntryKey, CancellationToken cancellationToken)
@@ -1063,10 +1065,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            await ExecuteLinkEntryAsync(new FluentCommand(command).Key(command.KeyValues), linkName, linkedEntryKey, cancellationToken);
+            await ExecuteLinkEntryAsync(new FluentCommand(command).Key(command.KeyValues), linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task UnlinkEntryAsync(FluentCommand command, string linkName, IDictionary<string, object> linkedEntryKey, CancellationToken cancellationToken)
@@ -1074,10 +1076,10 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            await ExecuteUnlinkEntryAsync(new FluentCommand(command).Key(command.KeyValues), linkName, linkedEntryKey, cancellationToken);
+            await ExecuteUnlinkEntryAsync(new FluentCommand(command).Key(command.KeyValues), linkName, linkedEntryKey, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task ExecuteAsync(FluentCommand command, CancellationToken cancellationToken)
@@ -1085,7 +1087,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return;
 
-            await ExecuteAsEnumerableAsync(command, cancellationToken);
+            await ExecuteAsEnumerableAsync(command, cancellationToken).ConfigureAwait(false);
         }
 
         internal async Task<IDictionary<string, object>> ExecuteAsSingleAsync(FluentCommand command, CancellationToken cancellationToken)
@@ -1093,7 +1095,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntry();
 
-            var result = await ExecuteAsEnumerableAsync(command, cancellationToken);
+            var result = await ExecuteAsEnumerableAsync(command, cancellationToken).ConfigureAwait(false);
             return result == null ? null : result.FirstOrDefault();
         }
 
@@ -1102,13 +1104,13 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsEntries();
 
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             if (command.HasFunction)
-                return await ExecuteFunctionAsync(command, cancellationToken);
+                return await ExecuteFunctionAsync(command, cancellationToken).ConfigureAwait(false);
             else if (command.HasAction)
-                return await ExecuteActionAsync(command, cancellationToken);
+                return await ExecuteActionAsync(command, cancellationToken).ConfigureAwait(false);
             else
                 throw new InvalidOperationException("Command is expected to be a function or an action.");
         }
@@ -1118,7 +1120,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsScalar<T>();
 
-            var result = await ExecuteAsSingleAsync(command, cancellationToken);
+            var result = await ExecuteAsSingleAsync(command, cancellationToken).ConfigureAwait(false);
             return IsBatchRequest
                 ? default(T)
                 : result == null 
@@ -1131,7 +1133,7 @@ namespace Simple.OData.Client
             if (IsBatchResponse)
                 return _batchResponse.AsArray<T>();
 
-            var result = await ExecuteAsEnumerableAsync(command, cancellationToken);
+            var result = await ExecuteAsEnumerableAsync(command, cancellationToken).ConfigureAwait(false);
             return IsBatchRequest
                 ? new T[] { }
                 : result == null
@@ -1143,10 +1145,10 @@ namespace Simple.OData.Client
 
         internal async Task ExecuteBatchAsync(IList<Func<IODataClient, Task>> actions, CancellationToken cancellationToken)
         {
-            await _session.ResolveAdapterAsync(cancellationToken);
+            await _session.ResolveAdapterAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
-            await ExecuteBatchActionsAsync(actions, cancellationToken);
+            await ExecuteBatchActionsAsync(actions, cancellationToken).ConfigureAwait(false);
         }
 
         private string ExtractFilterFromCommandText(string collection, string commandText)

--- a/Simple.OData.Client.Core/ODataClient.Internals.cs
+++ b/Simple.OData.Client.Core/ODataClient.Internals.cs
@@ -13,21 +13,21 @@ namespace Simple.OData.Client
         private async Task<IDictionary<string, object>> ExecuteInsertEntryAsync(FluentCommand command, bool resultRequired, CancellationToken cancellationToken)
         {
             var entryData = command.CommandData;
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateInsertRequestAsync(command.QualifiedEntityCollectionName, commandText, entryData, resultRequired);
+                .CreateInsertRequestAsync(command.QualifiedEntityCollectionName, commandText, entryData, resultRequired).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var result = await ExecuteRequestWithResultAsync(request, cancellationToken,
-                x => x.AsEntry(), () => null, () => request.EntryData);
+                x => x.AsEntry(), () => null, () => request.EntryData).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var keyNames = _session.Metadata.GetDeclaredKeyPropertyNames(commandText);
             if (result == null && resultRequired && Utils.AllMatch(keyNames, entryData.Keys, _session.Pluralizer))
             {
-                result = await this.GetEntryAsync(commandText, entryData, cancellationToken);
+                result = await this.GetEntryAsync(commandText, entryData, cancellationToken).ConfigureAwait(false);
                 if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
             }
 
@@ -41,20 +41,20 @@ namespace Simple.OData.Client
             var collectionName = command.QualifiedEntityCollectionName;
             var entryKey = command.HasKey ? command.KeyValues : command.FilterAsKey;
             var entryData = command.CommandData;
-            var entryIdent = await FormatEntryKeyAsync(command, cancellationToken);
+            var entryIdent = await FormatEntryKeyAsync(command, cancellationToken).ConfigureAwait(false);
 
-            var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter).CreateUpdateRequestAsync(collectionName, entryIdent, entryKey, entryData, resultRequired);
+            var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter).CreateUpdateRequestAsync(collectionName, entryIdent, entryKey, entryData, resultRequired).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var result = await ExecuteRequestWithResultAsync(request, cancellationToken,
-                x => x.AsEntry(), () => null, () => request.EntryData);
+                x => x.AsEntry(), () => null, () => request.EntryData).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             if (result == null && resultRequired)
             {
                 try
                 {
-                    result = await GetUpdatedResult(command, cancellationToken);
+                    result = await GetUpdatedResult(command, cancellationToken).ConfigureAwait(false);
                     if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
                 }
                 catch (Exception)
@@ -74,7 +74,7 @@ namespace Simple.OData.Client
             {
                 try
                 {
-                    await UnlinkEntryAsync(collectionName, entryKey, associationName, cancellationToken);
+                    await UnlinkEntryAsync(collectionName, entryKey, associationName, cancellationToken).ConfigureAwait(false);
                     if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
                 }
                 catch (Exception)
@@ -96,27 +96,27 @@ namespace Simple.OData.Client
                 updatedKey.Add(item);
             }
             var updatedCommand = new FluentCommand(command).Key(updatedKey);
-            return await FindEntryAsync(await updatedCommand.GetCommandTextAsync(cancellationToken), cancellationToken);
+            return await FindEntryAsync(await updatedCommand.GetCommandTextAsync(cancellationToken).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<IEnumerable<IDictionary<string, object>>> ExecuteUpdateEntriesAsync(FluentCommand command, bool resultRequired, CancellationToken cancellationToken)
         {
             return await IterateEntriesAsync(
                 command, resultRequired,
-                async (x, y, z, w) => await UpdateEntryAsync(x, y, z, w, cancellationToken),
-                cancellationToken);
+                async (x, y, z, w) => await UpdateEntryAsync(x, y, z, w, cancellationToken).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
         }
 
         private async Task ExecuteDeleteEntryAsync(FluentCommand command, CancellationToken cancellationToken)
         {
             var collectionName = command.QualifiedEntityCollectionName;
-            var entryIdent = await FormatEntryKeyAsync(command, cancellationToken);
+            var entryIdent = await FormatEntryKeyAsync(command, cancellationToken).ConfigureAwait(false);
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateDeleteRequestAsync(collectionName, entryIdent);
+                .CreateDeleteRequestAsync(collectionName, entryIdent).ConfigureAwait(false);
             if (!IsBatchRequest)
             {
-                using (await _requestRunner.ExecuteRequestAsync(request, cancellationToken))
+                using (await _requestRunner.ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                 }
             }
@@ -126,8 +126,8 @@ namespace Simple.OData.Client
         {
             return await IterateEntriesAsync(
                 command,
-                async (x, y) => await DeleteEntryAsync(x, y, cancellationToken),
-                cancellationToken);
+                async (x, y) => await DeleteEntryAsync(x, y, cancellationToken).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
         }
 
         private async Task ExecuteLinkEntryAsync(FluentCommand command, string linkName, IDictionary<string, object> linkedEntryKey, CancellationToken cancellationToken)
@@ -137,19 +137,19 @@ namespace Simple.OData.Client
             var collectionName = command.QualifiedEntityCollectionName;
             var entryKey = command.HasKey ? command.KeyValues : command.FilterAsKey;
 
-            var entryIdent = await FormatEntryKeyAsync(collectionName, entryKey, cancellationToken);
+            var entryIdent = await FormatEntryKeyAsync(collectionName, entryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var linkedCollection = _session.Metadata.GetNavigationPropertyPartnerTypeName(collectionName, linkName);
-            var linkIdent = await FormatEntryKeyAsync(linkedCollection, linkedEntryKey, cancellationToken);
+            var linkIdent = await FormatEntryKeyAsync(linkedCollection, linkedEntryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateLinkRequestAsync(collectionName, linkName, entryIdent, linkIdent);
+                .CreateLinkRequestAsync(collectionName, linkName, entryIdent, linkIdent).ConfigureAwait(false);
 
             if (!IsBatchRequest)
             {
-                using (await _requestRunner.ExecuteRequestAsync(request, cancellationToken))
+                using (await _requestRunner.ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                 }
             }
@@ -162,23 +162,23 @@ namespace Simple.OData.Client
             var collectionName = command.QualifiedEntityCollectionName;
             var entryKey = command.HasKey ? command.KeyValues : command.FilterAsKey;
 
-            var entryIdent = await FormatEntryKeyAsync(collectionName, entryKey, cancellationToken);
+            var entryIdent = await FormatEntryKeyAsync(collectionName, entryKey, cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             string linkIdent = null;
             if (linkedEntryKey != null)
             {
                 var linkedCollection = _session.Metadata.GetNavigationPropertyPartnerTypeName(collectionName, linkName);
-                linkIdent = await FormatEntryKeyAsync(linkedCollection, linkedEntryKey, cancellationToken);
+                linkIdent = await FormatEntryKeyAsync(linkedCollection, linkedEntryKey, cancellationToken).ConfigureAwait(false);
                 if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
             }
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateUnlinkRequestAsync(collectionName, linkName, entryIdent, linkIdent);
+                .CreateUnlinkRequestAsync(collectionName, linkName, entryIdent, linkIdent).ConfigureAwait(false);
 
             if (!IsBatchRequest)
             {
-                using (await _requestRunner.ExecuteRequestAsync(request, cancellationToken))
+                using (await _requestRunner.ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                 }
             }
@@ -186,28 +186,28 @@ namespace Simple.OData.Client
 
         private async Task<IEnumerable<IDictionary<string, object>>> ExecuteFunctionAsync(FluentCommand command, CancellationToken cancellationToken)
         {
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateFunctionRequestAsync(commandText, command.FunctionName);
+                .CreateFunctionRequestAsync(commandText, command.FunctionName).ConfigureAwait(false);
 
             return await ExecuteRequestWithResultAsync(request, cancellationToken,
                 x => x.AsEntries(),
-                () => new IDictionary<string, object>[] {});
+                () => new IDictionary<string, object>[] { }).ConfigureAwait(false);
         }
 
         private async Task<IEnumerable<IDictionary<string, object>>> ExecuteActionAsync(FluentCommand command, CancellationToken cancellationToken)
         {
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var request = await _session.Adapter.GetRequestWriter(_lazyBatchWriter)
-                .CreateActionRequestAsync(commandText, command.ActionName, command.CommandData, true);
+                .CreateActionRequestAsync(commandText, command.ActionName, command.CommandData, true).ConfigureAwait(false);
 
             return await ExecuteRequestWithResultAsync(request, cancellationToken,
                 x => x.AsEntries(),
-                () => new IDictionary<string, object>[] {});
+                () => new IDictionary<string, object>[] { }).ConfigureAwait(false);
         }
 
         private async Task ExecuteBatchActionsAsync(IList<Func<IODataClient, Task>> actions, CancellationToken cancellationToken)
@@ -216,17 +216,17 @@ namespace Simple.OData.Client
                 return;
 
             var responseIndexes = new List<int>();
-            var request = await _lazyBatchWriter.Value.CreateBatchRequestAsync(this, actions, responseIndexes);
+            var request = await _lazyBatchWriter.Value.CreateBatchRequestAsync(this, actions, responseIndexes).ConfigureAwait(false);
             if (request != null)
             {
                 // Execute batch and get response
-                using (var response = await _requestRunner.ExecuteRequestAsync(request, cancellationToken))
+                using (var response = await _requestRunner.ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     var responseReader = _session.Adapter.GetResponseReader();
-                    var batchResponse = await responseReader.GetResponseAsync(response, _session.Settings.IncludeAnnotationsInResults);
+                    var batchResponse = await responseReader.GetResponseAsync(response, _session.Settings.IncludeAnnotationsInResults).ConfigureAwait(false);
 
                     // Replay batch operations to assign results
-                    await responseReader.AssignBatchActionResultsAsync(this, batchResponse, actions, responseIndexes);
+                    await responseReader.AssignBatchActionResultsAsync(this, batchResponse, actions, responseIndexes).ConfigureAwait(false);
                 }
             }
         }
@@ -243,13 +243,13 @@ namespace Simple.OData.Client
 
             try
             {
-                using (var response = await _requestRunner.ExecuteRequestAsync(request, cancellationToken))
+                using (var response = await _requestRunner.ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false))
                 {
                     if (response.IsSuccessStatusCode && response.StatusCode != HttpStatusCode.NoContent &&
                         (request.Method == RestVerbs.Get || request.ResultRequired))
                     {
                         var responseReader = _session.Adapter.GetResponseReader();
-                        return createResult(await responseReader.GetResponseAsync(response, _session.Settings.IncludeAnnotationsInResults));
+                        return createResult(await responseReader.GetResponseAsync(response, _session.Settings.IncludeAnnotationsInResults).ConfigureAwait(false));
                     }
                     else
                     {
@@ -272,19 +272,19 @@ namespace Simple.OData.Client
         {
             var collectionName = command.QualifiedEntityCollectionName;
             var entryData = command.CommandData;
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             IEnumerable<IDictionary<string, object>> result = null;
             var client = new ODataClient(_settings);
-            var entries = await client.FindEntriesAsync(commandText, cancellationToken);
+            var entries = await client.FindEntriesAsync(commandText, cancellationToken).ConfigureAwait(false);
             if (entries != null)
             {
                 var entryList = entries.ToList();
                 var resultList = new List<IDictionary<string, object>>();
                 foreach (var entry in entryList)
                 {
-                    resultList.Add(await funcAsync(collectionName, entry, entryData, resultRequired));
+                    resultList.Add(await funcAsync(collectionName, entry, entryData, resultRequired).ConfigureAwait(false));
                     if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
                 }
                 result = resultList;
@@ -297,18 +297,18 @@ namespace Simple.OData.Client
             Func<string, IDictionary<string, object>, Task> funcAsync, CancellationToken cancellationToken)
         {
             var collectionName = command.QualifiedEntityCollectionName;
-            var commandText = await command.GetCommandTextAsync(cancellationToken);
+            var commandText = await command.GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
 
             var result = 0;
             var client = new ODataClient(_settings);
-            var entries = await client.FindEntriesAsync(commandText, cancellationToken);
+            var entries = await client.FindEntriesAsync(commandText, cancellationToken).ConfigureAwait(false);
             if (entries != null)
             {
                 var entryList = entries.ToList();
                 foreach (var entry in entryList)
                 {
-                    await funcAsync(collectionName, entry);
+                    await funcAsync(collectionName, entry).ConfigureAwait(false);
                     if (cancellationToken.IsCancellationRequested) cancellationToken.ThrowIfCancellationRequested();
                     ++result;
                 }
@@ -346,7 +346,7 @@ namespace Simple.OData.Client
             var entryIdent = await GetFluentClient()
                 .For(collection)
                 .Key(entryKey)
-                .GetCommandTextAsync(cancellationToken);
+                .GetCommandTextAsync(cancellationToken).ConfigureAwait(false);
 
             return entryIdent;
         }
@@ -355,7 +355,7 @@ namespace Simple.OData.Client
         {
             var entryIdent = command.HasKey
                 ? await command.GetCommandTextAsync(cancellationToken)
-                : await (new FluentCommand(command).Key(command.FilterAsKey).GetCommandTextAsync(cancellationToken));
+.ConfigureAwait(false) : await (new FluentCommand(command).Key(command.FilterAsKey).GetCommandTextAsync(cancellationToken)).ConfigureAwait(false);
 
             return entryIdent;
         }

--- a/Simple.OData.Client.Core/Session.cs
+++ b/Simple.OData.Client.Core/Session.cs
@@ -75,9 +75,9 @@ namespace Simple.OData.Client
                 IODataAdapter adapter;
                 if (string.IsNullOrEmpty(this.Settings.MetadataDocument))
                 {
-                    var response = await SendMetadataRequestAsync(cancellationToken);
-                    this.MetadataCache.SetMetadataDocument(await _adapterFactory.GetMetadataDocumentAsync(response));
-                    adapter = await _adapterFactory.CreateAdapterAsync(response);
+                    var response = await SendMetadataRequestAsync(cancellationToken).ConfigureAwait(false);
+                    this.MetadataCache.SetMetadataDocument(await _adapterFactory.GetMetadataDocumentAsync(response).ConfigureAwait(false));
+                    adapter = await _adapterFactory.CreateAdapterAsync(response).ConfigureAwait(false);
                 }
                 else
                 {
@@ -141,7 +141,7 @@ namespace Simple.OData.Client
         private async Task<HttpResponseMessage> SendMetadataRequestAsync(CancellationToken cancellationToken)
         {
             var request = new ODataRequest(RestVerbs.Get, this, ODataLiteral.Metadata);
-            return await new RequestRunner(this).ExecuteRequestAsync(request, cancellationToken);
+            return await new RequestRunner(this).ExecuteRequestAsync(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Simple.OData.Client.V3.Adapter/BatchWriter.cs
+++ b/Simple.OData.Client.V3.Adapter/BatchWriter.cs
@@ -29,8 +29,8 @@ namespace Simple.OData.Client.V3.Adapter
             _batchWriter = _messageWriter.CreateODataBatchWriter();
             _batchWriter.WriteStartBatch();
 #else
-            _batchWriter = await _messageWriter.CreateODataBatchWriterAsync();
-            await _batchWriter.WriteStartBatchAsync();
+            _batchWriter = await _messageWriter.CreateODataBatchWriterAsync().ConfigureAwait(false);
+            await _batchWriter.WriteStartBatchAsync().ConfigureAwait(false);
 #endif
             this.HasOperations = true;
         }
@@ -46,9 +46,9 @@ namespace Simple.OData.Client.V3.Adapter
             var stream = _requestMessage.GetStream();
 #else
             if (_pendingChangeSet)
-                await _batchWriter.WriteEndChangesetAsync();
-            await _batchWriter.WriteEndBatchAsync();
-            var stream = await _requestMessage.GetStreamAsync();
+                await _batchWriter.WriteEndChangesetAsync().ConfigureAwait(false);
+            await _batchWriter.WriteEndBatchAsync().ConfigureAwait(false);
+            var stream = await _requestMessage.GetStreamAsync().ConfigureAwait(false);
 #endif
             return CreateMessageFromStream(stream, _requestMessage.Url, _requestMessage.GetHeader);
         }
@@ -57,12 +57,12 @@ namespace Simple.OData.Client.V3.Adapter
         protected override async Task StartChangesetAsync()
         {
             if (_batchWriter == null)
-                await StartBatchAsync();
+                await StartBatchAsync().ConfigureAwait(false);
 
 #if SILVERLIGHT
             _batchWriter.WriteStartChangeset();
 #else
-            await _batchWriter.WriteStartChangesetAsync();
+            await _batchWriter.WriteStartChangesetAsync().ConfigureAwait(false);
 #endif
         }
 
@@ -79,9 +79,9 @@ namespace Simple.OData.Client.V3.Adapter
         protected override async Task<object> CreateOperationMessageAsync(Uri uri, string method, string collection, string contentId, bool resultRequired)
         {
             if (_batchWriter == null)
-                await StartBatchAsync();
+                await StartBatchAsync().ConfigureAwait(false);
 
-            return await CreateBatchOperationMessageAsync(uri, method, collection, contentId, resultRequired);
+            return await CreateBatchOperationMessageAsync(uri, method, collection, contentId, resultRequired).ConfigureAwait(false);
         }
 
 #pragma warning disable 1998
@@ -91,7 +91,7 @@ namespace Simple.OData.Client.V3.Adapter
 #if SILVERLIGHT
             var message = _batchWriter.CreateOperationRequestMessage(method, uri);
 #else
-            var message = await _batchWriter.CreateOperationRequestMessageAsync(method, uri);
+            var message = await _batchWriter.CreateOperationRequestMessageAsync(method, uri).ConfigureAwait(false);
 #endif
 
             if (method != RestVerbs.Get && method != RestVerbs.Delete)

--- a/Simple.OData.Client.V3.Adapter/RequestWriter.cs
+++ b/Simple.OData.Client.V3.Adapter/RequestWriter.cs
@@ -33,7 +33,7 @@ namespace Simple.OData.Client.V3.Adapter
 #endif
             message = IsBatch
                 ? await CreateBatchOperationMessageAsync(method, collection, entryData, commandText, resultRequired)
-                : new ODataRequestMessage();
+.ConfigureAwait(false) : new ODataRequestMessage();
 
             if (method == RestVerbs.Get || method == RestVerbs.Delete)
                 return null;
@@ -73,7 +73,7 @@ namespace Simple.OData.Client.V3.Adapter
 #if SILVERLIGHT
                 return message.GetStream();
 #else
-                return await message.GetStreamAsync();
+                return await message.GetStreamAsync().ConfigureAwait(false);
 #endif
             }
         }
@@ -88,7 +88,7 @@ namespace Simple.OData.Client.V3.Adapter
 #endif
  message = IsBatch
                 ? await CreateBatchOperationMessageAsync(method, null, null, commandText, false)
-                : new ODataRequestMessage();
+.ConfigureAwait(false) : new ODataRequestMessage();
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), _model))
             {
@@ -104,7 +104,7 @@ namespace Simple.OData.Client.V3.Adapter
 #if SILVERLIGHT
                 return message.GetStream();
 #else
-                return await message.GetStreamAsync();
+                return await message.GetStreamAsync().ConfigureAwait(false);
 #endif
             }
         }
@@ -113,7 +113,7 @@ namespace Simple.OData.Client.V3.Adapter
         protected override async Task<Stream> WriteFunctionContentAsync(string method, string commandText)
         {
             if (IsBatch)
-                await CreateBatchOperationMessageAsync(method, null, null, commandText, true);
+                await CreateBatchOperationMessageAsync(method, null, null, commandText, true).ConfigureAwait(false);
 
             return null;
         }
@@ -127,7 +127,7 @@ namespace Simple.OData.Client.V3.Adapter
 #endif
  message = IsBatch
                 ? await CreateBatchOperationMessageAsync(method, null, null, commandText, true)
-                : new ODataRequestMessage();
+.ConfigureAwait(false) : new ODataRequestMessage();
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), _model))
             {
@@ -139,8 +139,8 @@ namespace Simple.OData.Client.V3.Adapter
                     var parameterWriter = messageWriter.CreateODataParameterWriter(action);
                     parameterWriter.WriteStart();
 #else
-                    var parameterWriter = await messageWriter.CreateODataParameterWriterAsync(action);
-                    await parameterWriter.WriteStartAsync();
+                    var parameterWriter = await messageWriter.CreateODataParameterWriterAsync(action).ConfigureAwait(false);
+                    await parameterWriter.WriteStartAsync().ConfigureAwait(false);
 #endif
 
 
@@ -153,14 +153,14 @@ namespace Simple.OData.Client.V3.Adapter
 #if SILVERLIGHT
                     WriteOperationParameter(parameterWriter, operationParameter, parameter.Key, parameter.Value);
 #else
-                    await WriteOperationParameterAsync(parameterWriter, operationParameter, parameter.Key, parameter.Value);
+                    await WriteOperationParameterAsync(parameterWriter, operationParameter, parameter.Key, parameter.Value).ConfigureAwait(false);
 #endif
                 }
 
 #if SILVERLIGHT
                 parameterWriter.WriteEnd();
 #else
-                await parameterWriter.WriteEndAsync();
+                await parameterWriter.WriteEndAsync().ConfigureAwait(false);
 #endif
 
                 if (IsBatch)
@@ -169,7 +169,7 @@ namespace Simple.OData.Client.V3.Adapter
 #if SILVERLIGHT
                 return message.GetStream();
 #else
-                return await message.GetStreamAsync();
+                return await message.GetStreamAsync().ConfigureAwait(false);
 #endif
             }
         }
@@ -197,17 +197,17 @@ namespace Simple.OData.Client.V3.Adapter
         {
             if (operationParameter.Type.Definition.TypeKind == EdmTypeKind.Collection)
             {
-                var collectionWriter = await parameterWriter.CreateCollectionWriterAsync(paramName);
-                await collectionWriter.WriteStartAsync(new ODataCollectionStart());
+                var collectionWriter = await parameterWriter.CreateCollectionWriterAsync(paramName).ConfigureAwait(false);
+                await collectionWriter.WriteStartAsync(new ODataCollectionStart()).ConfigureAwait(false);
                 foreach (var item in paramValue as IEnumerable)
                 {
-                    await collectionWriter.WriteItemAsync(item);
+                    await collectionWriter.WriteItemAsync(item).ConfigureAwait(false);
                 }
-                await collectionWriter.WriteEndAsync();
+                await collectionWriter.WriteEndAsync().ConfigureAwait(false);
             }
             else
             {
-                await parameterWriter.WriteValueAsync(paramName, paramValue);
+                await parameterWriter.WriteValueAsync(paramName, paramValue).ConfigureAwait(false);
             }
         }
 #endif
@@ -282,8 +282,8 @@ namespace Simple.OData.Client.V3.Adapter
 #endif
         {
             var message = (await _deferredBatchWriter.Value.CreateOperationMessageAsync(
-                Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, commandText), 
-                method, collection, entryData, resultRequired))
+                Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, commandText),
+                method, collection, entryData, resultRequired).ConfigureAwait(false))
 #if SILVERLIGHT
                 as IODataRequestMessage;
 #else

--- a/Simple.OData.Client.V3.Adapter/ResponseReader.cs
+++ b/Simple.OData.Client.V3.Adapter/ResponseReader.cs
@@ -57,7 +57,7 @@ namespace Simple.OData.Client.V3.Adapter
 #if SILVERLIGHT
                         var stream = responseMessage.GetStream();
 #else
-                        var stream = await responseMessage.GetStreamAsync();
+                        var stream = await responseMessage.GetStreamAsync().ConfigureAwait(false);
 #endif
                         var text = Client.Utils.StreamToString(stream, responseMessage is ODataBatchOperationResponseMessage);
                         return ODataResponse.FromFeed(new[] { new Dictionary<string, object>()
@@ -68,7 +68,7 @@ namespace Simple.OData.Client.V3.Adapter
                 }
                 else if (payloadKind.Any(x => x.PayloadKind == ODataPayloadKind.Batch))
                 {
-                    return await ReadResponse(messageReader.CreateODataBatchReader(), includeAnnotationsInResults);
+                    return await ReadResponse(messageReader.CreateODataBatchReader(), includeAnnotationsInResults).ConfigureAwait(false);
                 }
                 else if (payloadKind.Any(x => x.PayloadKind == ODataPayloadKind.Feed))
                 {
@@ -123,10 +123,10 @@ namespace Simple.OData.Client.V3.Adapter
 #if SILVERLIGHT
                                 operationMessage.GetStream()));
 #else
-                                await operationMessage.GetStreamAsync()));
+                                await operationMessage.GetStreamAsync().ConfigureAwait(false)));
 #endif
                         else
-                            batch.Add(await GetResponseAsync(operationMessage));
+                            batch.Add(await GetResponseAsync(operationMessage).ConfigureAwait(false));
                         break;
                     case ODataBatchReaderState.ChangesetEnd:
                         break;

--- a/Simple.OData.Client.V4.Adapter/BatchWriter.cs
+++ b/Simple.OData.Client.V4.Adapter/BatchWriter.cs
@@ -24,26 +24,26 @@ namespace Simple.OData.Client.V4.Adapter
         {
             _requestMessage = new ODataRequestMessage() { Url = _session.Settings.BaseUri };
             _messageWriter = new ODataMessageWriter(_requestMessage);
-            _batchWriter = await _messageWriter.CreateODataBatchWriterAsync();
-            await _batchWriter.WriteStartBatchAsync();
+            _batchWriter = await _messageWriter.CreateODataBatchWriterAsync().ConfigureAwait(false);
+            await _batchWriter.WriteStartBatchAsync().ConfigureAwait(false);
             this.HasOperations = true;
         }
 
         public override async Task<HttpRequestMessage> EndBatchAsync()
         {
             if (_pendingChangeSet)
-                await _batchWriter.WriteEndChangesetAsync();
-            await _batchWriter.WriteEndBatchAsync();
-            var stream = await _requestMessage.GetStreamAsync();
+                await _batchWriter.WriteEndChangesetAsync().ConfigureAwait(false);
+            await _batchWriter.WriteEndBatchAsync().ConfigureAwait(false);
+            var stream = await _requestMessage.GetStreamAsync().ConfigureAwait(false);
             return CreateMessageFromStream(stream, _requestMessage.Url, _requestMessage.GetHeader);
         }
 
         protected override async Task StartChangesetAsync()
         {
             if (_batchWriter == null)
-                await StartBatchAsync();
+                await StartBatchAsync().ConfigureAwait(false);
 
-            await _batchWriter.WriteStartChangesetAsync();
+            await _batchWriter.WriteStartChangesetAsync().ConfigureAwait(false);
         }
 
         protected override Task EndChangesetAsync()
@@ -54,15 +54,15 @@ namespace Simple.OData.Client.V4.Adapter
         protected override async Task<object> CreateOperationMessageAsync(Uri uri, string method, string collection, string contentId, bool resultRequired)
         {
             if (_batchWriter == null)
-                await StartBatchAsync();
+                await StartBatchAsync().ConfigureAwait(false);
 
-            return await CreateBatchOperationMessageAsync(uri, method, collection, contentId, resultRequired);
+            return await CreateBatchOperationMessageAsync(uri, method, collection, contentId, resultRequired).ConfigureAwait(false);
         }
 
         private async Task<ODataBatchOperationRequestMessage> CreateBatchOperationMessageAsync(
             Uri uri, string method, string collection, string contentId, bool resultRequired)
         {
-            var message = await _batchWriter.CreateOperationRequestMessageAsync(method, uri, contentId);
+            var message = await _batchWriter.CreateOperationRequestMessageAsync(method, uri, contentId).ConfigureAwait(false);
 
             if (method == RestVerbs.Post || method == RestVerbs.Put || method == RestVerbs.Patch)
                 message.SetHeader(HttpLiteral.ContentId, contentId);

--- a/Simple.OData.Client.V4.Adapter/RequestWriter.cs
+++ b/Simple.OData.Client.V4.Adapter/RequestWriter.cs
@@ -27,7 +27,7 @@ namespace Simple.OData.Client.V4.Adapter
         protected override async Task<Stream> WriteEntryContentAsync(string method, string collection, string commandText, IDictionary<string, object> entryData, bool resultRequired)
         {
             IODataRequestMessageAsync message = IsBatch
-                ? await CreateBatchOperationMessageAsync(method, collection, entryData, commandText, resultRequired)
+                ? await CreateBatchOperationMessageAsync(method, collection, entryData, commandText, resultRequired).ConfigureAwait(false)
                 : new ODataRequestMessage();
 
             if (method == RestVerbs.Get || method == RestVerbs.Delete)
@@ -44,10 +44,10 @@ namespace Simple.OData.Client.V4.Adapter
                 var entityCollection = _session.Metadata.NavigateToCollection(collection);
                 var entryDetails = _session.Metadata.ParseEntryDetails(entityCollection.Name, entryData, contentId);
 
-                var entryWriter = await messageWriter.CreateODataEntryWriterAsync();
+                var entryWriter = await messageWriter.CreateODataEntryWriterAsync().ConfigureAwait(false);
                 var entry = CreateODataEntry(entityType.FullName(), entryDetails.Properties);
 
-                await entryWriter.WriteStartAsync(entry);
+                await entryWriter.WriteStartAsync(entry).ConfigureAwait(false);
 
                 if (entryDetails.Links != null)
                 {
@@ -55,13 +55,13 @@ namespace Simple.OData.Client.V4.Adapter
                     {
                         if (link.Value.Any(x => x.LinkData != null))
                         {
-                            await WriteLinkAsync(entryWriter, entry, link.Key, link.Value);
+                            await WriteLinkAsync(entryWriter, entry, link.Key, link.Value).ConfigureAwait(false);
                         }
                     }
                 }
 
-                await entryWriter.WriteEndAsync();
-                return IsBatch ? null : await message.GetStreamAsync();
+                await entryWriter.WriteEndAsync().ConfigureAwait(false);
+                return IsBatch ? null : await message.GetStreamAsync().ConfigureAwait(false);
             }
         }
 
@@ -69,7 +69,7 @@ namespace Simple.OData.Client.V4.Adapter
         {
             var message = IsBatch
                 ? await CreateBatchOperationMessageAsync(method, null, null, commandText, false)
-                : new ODataRequestMessage();
+.ConfigureAwait(false) : new ODataRequestMessage();
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), _model))
             {
@@ -77,15 +77,15 @@ namespace Simple.OData.Client.V4.Adapter
                 {
                     Url = Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, linkIdent)
                 };
-                await messageWriter.WriteEntityReferenceLinkAsync(link);
-                return IsBatch ? null : await message.GetStreamAsync();
+                await messageWriter.WriteEntityReferenceLinkAsync(link).ConfigureAwait(false);
+                return IsBatch ? null : await message.GetStreamAsync().ConfigureAwait(false);
             }
         }
 
         protected override async Task<Stream> WriteFunctionContentAsync(string method, string commandText)
         {
             if (IsBatch)
-                await CreateBatchOperationMessageAsync(method, null, null, commandText, true);
+                await CreateBatchOperationMessageAsync(method, null, null, commandText, true).ConfigureAwait(false);
 
             return null;
         }
@@ -94,16 +94,16 @@ namespace Simple.OData.Client.V4.Adapter
         {
             IODataRequestMessageAsync message = IsBatch
                 ? await CreateBatchOperationMessageAsync(method, null, null, commandText, true)
-                : new ODataRequestMessage();
+.ConfigureAwait(false) : new ODataRequestMessage();
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), _model))
             {
                 var action = _model.SchemaElements.BestMatch(
                     x => x.SchemaElementKind == EdmSchemaElementKind.Action,
                     x => x.Name, actionName, _session.Pluralizer) as IEdmAction;
-                var parameterWriter = await messageWriter.CreateODataParameterWriterAsync(action);
+                var parameterWriter = await messageWriter.CreateODataParameterWriterAsync(action).ConfigureAwait(false);
 
-                await parameterWriter.WriteStartAsync();
+                await parameterWriter.WriteStartAsync().ConfigureAwait(false);
 
                 foreach (var parameter in parameters)
                 {
@@ -111,11 +111,11 @@ namespace Simple.OData.Client.V4.Adapter
                     if (operationParameter == null)
                         throw new UnresolvableObjectException(parameter.Key, string.Format("Parameter [{0}] not found for action [{1}]", parameter.Key, actionName));
 
-                    await WriteOperationParameterAsync(parameterWriter, operationParameter, parameter.Key, parameter.Value);
+                    await WriteOperationParameterAsync(parameterWriter, operationParameter, parameter.Key, parameter.Value).ConfigureAwait(false);
                 }
 
-                await parameterWriter.WriteEndAsync();
-                return IsBatch ? null : await message.GetStreamAsync();
+                await parameterWriter.WriteEndAsync().ConfigureAwait(false);
+                return IsBatch ? null : await message.GetStreamAsync().ConfigureAwait(false);
             }
         }
 
@@ -125,18 +125,18 @@ namespace Simple.OData.Client.V4.Adapter
             {
                 case EdmTypeKind.Primitive:
                 case EdmTypeKind.Complex:
-                    await parameterWriter.WriteValueAsync(paramName, paramValue);
+                    await parameterWriter.WriteValueAsync(paramName, paramValue).ConfigureAwait(false);
                     break;
 
                 case EdmTypeKind.Enum:
-                    await parameterWriter.WriteValueAsync(paramName, new ODataEnumValue(paramValue.ToString()));
+                    await parameterWriter.WriteValueAsync(paramName, new ODataEnumValue(paramValue.ToString())).ConfigureAwait(false);
                     break;
 
                 case EdmTypeKind.Entity:
-                    var entryWriter = await parameterWriter.CreateEntryWriterAsync(paramName);
+                    var entryWriter = await parameterWriter.CreateEntryWriterAsync(paramName).ConfigureAwait(false);
                     var entry = CreateODataEntry(operationParameter.Type.Definition.FullTypeName(), paramValue.ToDictionary());
-                    await entryWriter.WriteStartAsync(entry);
-                    await entryWriter.WriteEndAsync();
+                    await entryWriter.WriteStartAsync(entry).ConfigureAwait(false);
+                    await entryWriter.WriteEndAsync().ConfigureAwait(false);
                     break;
 
                 case EdmTypeKind.Collection:
@@ -144,27 +144,27 @@ namespace Simple.OData.Client.V4.Adapter
                     var elementType = collectionType.ElementType;
                     if (elementType.Definition.TypeKind == EdmTypeKind.Entity)
                     {
-                        var feedWriter = await parameterWriter.CreateFeedWriterAsync(paramName);
+                        var feedWriter = await parameterWriter.CreateFeedWriterAsync(paramName).ConfigureAwait(false);
                         var feed = new ODataFeed();
-                        await feedWriter.WriteStartAsync(feed);
+                        await feedWriter.WriteStartAsync(feed).ConfigureAwait(false);
                         foreach (var item in paramValue as IEnumerable)
                         {
                             var feedEntry = CreateODataEntry(elementType.Definition.FullTypeName(), item.ToDictionary());
 
-                            await feedWriter.WriteStartAsync(feedEntry);
-                            await feedWriter.WriteEndAsync();
+                            await feedWriter.WriteStartAsync(feedEntry).ConfigureAwait(false);
+                            await feedWriter.WriteEndAsync().ConfigureAwait(false);
                         }
-                        await feedWriter.WriteEndAsync();
+                        await feedWriter.WriteEndAsync().ConfigureAwait(false);
                     }
                     else
                     {
-                        var collectionWriter = await parameterWriter.CreateCollectionWriterAsync(paramName);
-                        await collectionWriter.WriteStartAsync(new ODataCollectionStart());
+                        var collectionWriter = await parameterWriter.CreateCollectionWriterAsync(paramName).ConfigureAwait(false);
+                        await collectionWriter.WriteStartAsync(new ODataCollectionStart()).ConfigureAwait(false);
                         foreach (var item in paramValue as IEnumerable)
                         {
-                            await collectionWriter.WriteItemAsync(item);
+                            await collectionWriter.WriteItemAsync(item).ConfigureAwait(false);
                         }
-                        await collectionWriter.WriteEndAsync();
+                        await collectionWriter.WriteEndAsync().ConfigureAwait(false);
                     }
                     break;
 
@@ -196,7 +196,7 @@ namespace Simple.OData.Client.V4.Adapter
         {
             var message = (await _deferredBatchWriter.Value.CreateOperationMessageAsync(
                 Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, commandText),
-                method, collection, entryData, resultRequired)) as IODataRequestMessageAsync;
+                method, collection, entryData, resultRequired).ConfigureAwait(false)) as IODataRequestMessageAsync;
 
             return message;
         }
@@ -219,7 +219,7 @@ namespace Simple.OData.Client.V4.Adapter
                 Name = linkName,
                 IsCollection = isCollection,
                 Url = new Uri(ODataNamespace.Related + linkType, UriKind.Absolute),
-            });
+            }).ConfigureAwait(false);
 
             foreach (var referenceLink in links)
             {
@@ -245,10 +245,10 @@ namespace Simple.OData.Client.V4.Adapter
                     Url = Utils.CreateAbsoluteUri(_session.Settings.BaseUri.AbsoluteUri, linkUri)
                 };
 
-                await entryWriter.WriteEntityReferenceLinkAsync(link);
+                await entryWriter.WriteEntityReferenceLinkAsync(link).ConfigureAwait(false);
             }
 
-            await entryWriter.WriteEndAsync();
+            await entryWriter.WriteEndAsync().ConfigureAwait(false);
         }
 
         private static IEdmEntityType GetNavigationPropertyEntityType(IEdmNavigationProperty navigationProperty)

--- a/Simple.OData.Client.V4.Adapter/ResponseReader.cs
+++ b/Simple.OData.Client.V4.Adapter/ResponseReader.cs
@@ -46,7 +46,7 @@ namespace Simple.OData.Client.V4.Adapter
                     }
                     else
                     {
-                        var text = Utils.StreamToString(await responseMessage.GetStreamAsync(), responseMessage is ODataBatchOperationResponseMessage);
+                        var text = Utils.StreamToString(await responseMessage.GetStreamAsync().ConfigureAwait(false), responseMessage is ODataBatchOperationResponseMessage);
                         return ODataResponse.FromFeed(new[] { new Dictionary<string, object>()
                         {
                             { FluentCommand.ResultLiteral, text }
@@ -55,7 +55,7 @@ namespace Simple.OData.Client.V4.Adapter
                 }
                 else if (payloadKind.Any(x => x.PayloadKind == ODataPayloadKind.Batch))
                 {
-                    return await ReadResponse(messageReader.CreateODataBatchReader(), includeAnnotationsInResults);
+                    return await ReadResponse(messageReader.CreateODataBatchReader(), includeAnnotationsInResults).ConfigureAwait(false);
                 }
                 else if (payloadKind.Any(x => x.PayloadKind == ODataPayloadKind.Feed))
                 {
@@ -97,9 +97,9 @@ namespace Simple.OData.Client.V4.Adapter
                         else if (operationMessage.StatusCode >= (int)HttpStatusCode.BadRequest)
                             batch.Add(ODataResponse.FromStatusCode(
                                 operationMessage.StatusCode,
-                                await operationMessage.GetStreamAsync()));
+                                await operationMessage.GetStreamAsync().ConfigureAwait(false)));
                         else
-                            batch.Add(await GetResponseAsync(operationMessage));
+                            batch.Add(await GetResponseAsync(operationMessage).ConfigureAwait(false));
                         break;
                     case ODataBatchReaderState.ChangesetEnd:
                         break;


### PR DESCRIPTION
There is no sense to return back to the same thread which was initiator of the async operation inside library.