### PR TITLE
New properties on a service don't break existing running clients

### DIFF
--- a/Simple.OData.Client.V3.Adapter/ResponseReader.cs
+++ b/Simple.OData.Client.V3.Adapter/ResponseReader.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using Microsoft.Data.Edm;
+using Microsoft.Data.OData;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.Data.Edm;
-using Microsoft.Data.OData;
 
 #pragma warning disable 1591
 
@@ -30,10 +30,14 @@ namespace Simple.OData.Client.V3.Adapter
 #if SILVERLIGHT
         public async Task<ODataResponse> GetResponseAsync(IODataResponseMessage responseMessage)
 #else
+
         public async Task<ODataResponse> GetResponseAsync(IODataResponseMessageAsync responseMessage)
 #endif
         {
-            var readerSettings = new ODataMessageReaderSettings();
+            var readerSettings = new ODataMessageReaderSettings
+            {
+                UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty
+            };
             readerSettings.MessageQuotas.MaxReceivedMessageSize = Int32.MaxValue;
             readerSettings.ShouldIncludeAnnotation = x => _session.Settings.IncludeAnnotationsInResults;
             using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model))
@@ -106,6 +110,7 @@ namespace Simple.OData.Client.V3.Adapter
                 {
                     case ODataBatchReaderState.ChangesetStart:
                         break;
+
                     case ODataBatchReaderState.Operation:
                         var operationMessage = odataReader.CreateOperationResponseMessage();
                         if (operationMessage.StatusCode == (int)HttpStatusCode.NoContent)
@@ -121,6 +126,7 @@ namespace Simple.OData.Client.V3.Adapter
                         else
                             batch.Add(await GetResponseAsync(operationMessage).ConfigureAwait(false));
                         break;
+
                     case ODataBatchReaderState.ChangesetEnd:
                         break;
                 }
@@ -195,6 +201,7 @@ namespace Simple.OData.Client.V3.Adapter
 
             return ODataResponse.FromNode(rootNode);
         }
+
         protected override void ConvertEntry(ResponseNode entryNode, object entry)
         {
             if (entry != null)

--- a/Simple.OData.Client.V4.Adapter/ResponseReader.cs
+++ b/Simple.OData.Client.V4.Adapter/ResponseReader.cs
@@ -1,11 +1,11 @@
-﻿using System;
+﻿using Microsoft.OData.Core;
+using Microsoft.OData.Edm;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.OData.Core;
-using Microsoft.OData.Edm;
 
 #pragma warning disable 1591
 
@@ -28,7 +28,10 @@ namespace Simple.OData.Client.V4.Adapter
 
         public async Task<ODataResponse> GetResponseAsync(IODataResponseMessageAsync responseMessage)
         {
-            var readerSettings = new ODataMessageReaderSettings();
+            var readerSettings = new ODataMessageReaderSettings
+            {
+                UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty
+            };
             readerSettings.MessageQuotas.MaxReceivedMessageSize = Int32.MaxValue;
             readerSettings.ShouldIncludeAnnotation = x => _session.Settings.IncludeAnnotationsInResults;
             using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model))
@@ -83,6 +86,7 @@ namespace Simple.OData.Client.V4.Adapter
                 {
                     case ODataBatchReaderState.ChangesetStart:
                         break;
+
                     case ODataBatchReaderState.Operation:
                         var operationMessage = odataReader.CreateOperationResponseMessage();
                         if (operationMessage.StatusCode == (int)HttpStatusCode.NoContent)
@@ -94,6 +98,7 @@ namespace Simple.OData.Client.V4.Adapter
                         else
                             batch.Add(await GetResponseAsync(operationMessage).ConfigureAwait(false));
                         break;
+
                     case ODataBatchReaderState.ChangesetEnd:
                         break;
                 }


### PR DESCRIPTION
This is a fix to #301 based on the suggestion of @beforeyousreejesh. I tried it in my [issue demo solution](https://github.com/vojtechvit/ODataClientCacheProblemDemo) by compiling and replacing the Simple OData Client DLLs and it worked as expected - no exception is thrown anymore when a new property is added to the service model on the service side while the old service model is cached on the client.