### PR TITLE
Backward Compatibility for update method using MERGE Http method

### DIFF
--- a/Simple.OData.Client.Core/Adapter/RequestWriterBase.cs
+++ b/Simple.OData.Client.Core/Adapter/RequestWriterBase.cs
@@ -78,10 +78,17 @@ namespace Simple.OData.Client
             if (HasUpdatedKeyProperties(collection, entryKey, entryData))
                 usePatch = false;
 
-            var entryContent = await WriteEntryContentAsync(
-                usePatch ? RestVerbs.Patch : RestVerbs.Put, collection, entryIdent, entryData, resultRequired).ConfigureAwait(false);
-
             var updateMethod = usePatch ? RestVerbs.Patch : RestVerbs.Put;
+
+            updateMethod = _session.Settings.PreferredUpdateMethod == ODataUpdateMethod.Merge ? RestVerbs.Merge : updateMethod;
+
+            var entryContent = await WriteEntryContentAsync(
+                updateMethod, collection, entryIdent, entryData, resultRequired).ConfigureAwait(false);
+
+
+
+
+
             var checkOptimisticConcurrency = _session.Metadata.EntityCollectionRequiresOptimisticConcurrencyCheck(collection);
             var request = new ODataRequest(updateMethod, _session, entryIdent, entryData, entryContent)
             {

--- a/Simple.OData.Client.Core/Http/RequestRunner.cs
+++ b/Simple.OData.Client.Core/Http/RequestRunner.cs
@@ -86,6 +86,7 @@ namespace Simple.OData.Client
             if (request.CheckOptimisticConcurrency &&
                 (request.Method == RestVerbs.Put ||
                  request.Method == RestVerbs.Patch ||
+                 request.Method == RestVerbs.Merge ||
                  request.Method == RestVerbs.Delete))
             {
                 request.RequestMessage.Headers.IfMatch.Add(EntityTagHeaderValue.Any);

--- a/Simple.OData.Client.Core/Http/RestVerbs.cs
+++ b/Simple.OData.Client.Core/Http/RestVerbs.cs
@@ -7,6 +7,7 @@ namespace Simple.OData.Client
         public const string Get = "GET";
         public const string Post = "POST";
         public const string Put = "PUT";
+        public const string Merge = "MERGE";
         public const string Patch = "PATCH";
         public const string Delete = "DELETE";
         // ReSharper restore InconsistentNaming

--- a/Simple.OData.Client.Core/ODataUpdateMethod.cs
+++ b/Simple.OData.Client.Core/ODataUpdateMethod.cs
@@ -9,7 +9,12 @@
         /// Use PATCH to update OData entries
         /// </summary>
         Patch,
+        /// <summary>
+        /// Use MERGE to update OData entries
+        /// </summary>
 
+        [System.Obsolete("This method is obsolete. Use Patch instead.")]
+        Merge,
         /// <summary>
         /// Use PUT to update OData entries
         /// </summary>

--- a/Simple.OData.Client.V3.Adapter/BatchWriter.cs
+++ b/Simple.OData.Client.V3.Adapter/BatchWriter.cs
@@ -97,11 +97,11 @@ namespace Simple.OData.Client.V3.Adapter
             if (method != RestVerbs.Get && method != RestVerbs.Delete)
                 message.SetHeader(HttpLiteral.ContentId, contentId);
 
-            if (method == RestVerbs.Post || method == RestVerbs.Put || method == RestVerbs.Patch)
+            if (method == RestVerbs.Post || method == RestVerbs.Put || method == RestVerbs.Patch || method == RestVerbs.Merge)
                 message.SetHeader(HttpLiteral.Prefer, resultRequired ? HttpLiteral.ReturnContent : HttpLiteral.ReturnNoContent);
 
             if (collection != null && _session.Metadata.EntityCollectionRequiresOptimisticConcurrencyCheck(collection) &&
-                (method == RestVerbs.Put || method == RestVerbs.Patch || method == RestVerbs.Delete))
+                (method == RestVerbs.Put || method == RestVerbs.Patch || method == RestVerbs.Merge || method == RestVerbs.Delete))
             {
                 message.SetHeader(HttpLiteral.IfMatch, EntityTagHeaderValue.Any.Tag);
             }

--- a/Simple.OData.Client.V3.Adapter/RequestWriter.cs
+++ b/Simple.OData.Client.V3.Adapter/RequestWriter.cs
@@ -40,7 +40,7 @@ namespace Simple.OData.Client.V3.Adapter
 
             var entityType = _model.FindDeclaredType(
                 _session.Metadata.GetQualifiedTypeName(collection)) as IEdmEntityType;
-            var model = method == RestVerbs.Patch ? new EdmDeltaModel(_model, entityType, entryData.Keys) : _model;
+            var model = (method == RestVerbs.Patch || method == RestVerbs.Merge) ? new EdmDeltaModel(_model, entityType, entryData.Keys) : _model;
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), model))
             {

--- a/Simple.OData.Client.V4.Adapter/BatchWriter.cs
+++ b/Simple.OData.Client.V4.Adapter/BatchWriter.cs
@@ -64,14 +64,14 @@ namespace Simple.OData.Client.V4.Adapter
         {
             var message = await _batchWriter.CreateOperationRequestMessageAsync(method, uri, contentId).ConfigureAwait(false);
 
-            if (method == RestVerbs.Post || method == RestVerbs.Put || method == RestVerbs.Patch)
+            if (method == RestVerbs.Post || method == RestVerbs.Put || method == RestVerbs.Patch || method == RestVerbs.Merge)
                 message.SetHeader(HttpLiteral.ContentId, contentId);
 
-            if (method == RestVerbs.Post || method == RestVerbs.Put || method == RestVerbs.Patch)
+            if (method == RestVerbs.Post || method == RestVerbs.Put || method == RestVerbs.Patch || method == RestVerbs.Merge)
                 message.SetHeader(HttpLiteral.Prefer, resultRequired ? HttpLiteral.ReturnRepresentation : HttpLiteral.ReturnMinimal);
 
             if (collection != null && _session.Metadata.EntityCollectionRequiresOptimisticConcurrencyCheck(collection) &&
-                (method == RestVerbs.Put || method == RestVerbs.Patch || method == RestVerbs.Delete))
+                (method == RestVerbs.Put || method == RestVerbs.Patch || method == RestVerbs.Merge || method == RestVerbs.Delete))
             {
                 message.SetHeader(HttpLiteral.IfMatch, EntityTagHeaderValue.Any.Tag);
             }

--- a/Simple.OData.Client.V4.Adapter/RequestWriter.cs
+++ b/Simple.OData.Client.V4.Adapter/RequestWriter.cs
@@ -35,7 +35,7 @@ namespace Simple.OData.Client.V4.Adapter
 
             var entityType = _model.FindDeclaredType(
                 _session.Metadata.GetQualifiedTypeName(collection)) as IEdmEntityType;
-            var model = method == RestVerbs.Patch ? new EdmDeltaModel(_model, entityType, entryData.Keys) : _model;
+            var model = (method == RestVerbs.Patch || method == RestVerbs.Merge) ? new EdmDeltaModel(_model, entityType, entryData.Keys) : _model;
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), model))
             {
@@ -93,7 +93,7 @@ namespace Simple.OData.Client.V4.Adapter
         protected override async Task<Stream> WriteActionContentAsync(string method, string commandText, string actionName, string boundTypeName, IDictionary<string, object> parameters)
         {
             IODataRequestMessageAsync message = IsBatch
-                ? await CreateBatchOperationMessageAsync(method, null, null, commandText, true).ConfigureAwait(false) 
+                ? await CreateBatchOperationMessageAsync(method, null, null, commandText, true).ConfigureAwait(false)
                 : new ODataRequestMessage();
 
             using (var messageWriter = new ODataMessageWriter(message, GetWriterSettings(), _model))
@@ -111,7 +111,7 @@ namespace Simple.OData.Client.V4.Adapter
                     : _model.SchemaElements.BestMatch(
                         x => x.SchemaElementKind == EdmSchemaElementKind.Action
                              && typeMatch(
-                                 ((IEdmAction) x).Parameters.FirstOrDefault(p => p.Name == "bindingParameter"),
+                                 ((IEdmAction)x).Parameters.FirstOrDefault(p => p.Name == "bindingParameter"),
                                  _model.FindDeclaredType(boundTypeName)),
                         x => x.Name, actionName, _session.Pluralizer) as IEdmAction;
                 var parameterWriter = await messageWriter.CreateODataParameterWriterAsync(action).ConfigureAwait(false);

--- a/Solutions/.vs/config/applicationhost.config
+++ b/Solutions/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="Simple.OData.NorthwindService" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Projects\Git\Simple.OData.Client\Simple.OData.NorthwindService" />
+                    <virtualDirectory path="/" physicalPath="F:\WorkingProjects\SimpleOdata\Simple.OData.NorthwindService" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:55172:localhost" />

--- a/Solutions/Simple.OData.Client.All.sln
+++ b/Solutions/Simple.OData.Client.All.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D1D23CCD-C556-480A-8817-6FD58817A0C8}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
Since this library works with OData versions v1-v4 ([as OData.org says](http://www.odata.org/libraries/)) my xamarin app was not able to create an update request, because my service doesn't implement PATCH method but MERGE. So, may be good idea to keep this method.