### PR TITLE
Fixed issue #313

### DIFF
--- a/Simple.OData.Client.Tests.Core/ExpansionTests.cs
+++ b/Simple.OData.Client.Tests.Core/ExpansionTests.cs
@@ -211,6 +211,21 @@ namespace Simple.OData.Client.Tests
             Assert.Equal(expectedCommand, commandText);
         }
 
+        [Theory]
+        [InlineData("Northwind.xml", "Products?$expand=Category&$select=ProductName,Category/CategoryName&$orderby=Category/CategoryName,ProductName")]
+        [InlineData("Northwind4.xml", "Products?$expand=Category($select=CategoryName)&$select=ProductName&$orderby=Category/CategoryName,ProductName")]
+        public async Task ExpandCategorySelectProductNameCategoryNameThenOrderByCategoryNameThenByProductName(string metadataFile, string expectedCommand)
+        {
+            var client = CreateClient(metadataFile);
+            var command = client.For<Product>()
+                .Expand(p => p.Category)
+                .Select(p => new { p.ProductName, p.Category.CategoryName })
+                .OrderBy(p => p.Category.CategoryName)
+                .ThenBy(p => p.ProductName);
+            string commandText = await command.GetCommandTextAsync();
+            Assert.Equal(expectedCommand, commandText);
+        }
+
         [Fact]
         public async Task ExpandSubordinates2LevelsByValue()
         {


### PR DESCRIPTION
Corrected command URL formatting for queries with Expand() and multiple OrderBy()/ThenBy() ordering (with and without expanded properties).

This should fix issue https://github.com/object/Simple.OData.Client/issues/313.