### PR TITLE
Fixed Issues #355 and #356

### DIFF
--- a/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
+++ b/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
@@ -173,11 +173,15 @@ namespace Simple.OData.Client
             var navigationPath = FormatCallerReference();
             var entityCollection = context.Session.Metadata.NavigateToCollection(context.EntityCollection, navigationPath);
 
-            var targetQualifier = string.Format("x{0}", ArgumentCounter >= 0 ? (1 + (ArgumentCounter++) % 9).ToString() : string.Empty);
-            var formattedArguments = string.Format("{0}:{1}",
-                targetQualifier,
-                FormatExpression(this.Function.Arguments.First(), new ExpressionContext(context.Session,
-                    entityCollection, targetQualifier, context.DynamicPropertiesContainerName)));
+            string formattedArguments = string.Empty;
+            if (this.Function.Arguments.Any() || this.Function.FunctionName != ODataLiteral.Any)
+            {
+                var targetQualifier = string.Format("x{0}", ArgumentCounter >= 0 ? (1 + (ArgumentCounter++) % 9).ToString() : string.Empty);
+                formattedArguments = string.Format("{0}:{1}",
+                    targetQualifier,
+                    FormatExpression(this.Function.Arguments.First(), new ExpressionContext(context.Session,
+                        entityCollection, targetQualifier, context.DynamicPropertiesContainerName)));
+            }
 
             return FormatScope(
                 string.Format("{0}/{1}({2})",

--- a/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
+++ b/Simple.OData.Client.Core/Expressions/ODataExpression.Format.cs
@@ -173,8 +173,12 @@ namespace Simple.OData.Client
             var navigationPath = FormatCallerReference();
             var entityCollection = context.Session.Metadata.NavigateToCollection(context.EntityCollection, navigationPath);
 
-            string formattedArguments = string.Empty;
-            if (this.Function.Arguments.Any() || this.Function.FunctionName != ODataLiteral.Any)
+            string formattedArguments;
+            if(!this.Function.Arguments.Any() && string.Equals(this.Function.FunctionName, ODataLiteral.Any, StringComparison.OrdinalIgnoreCase))
+            {
+                formattedArguments = string.Empty;
+            }
+            else
             {
                 var targetQualifier = string.Format("x{0}", ArgumentCounter >= 0 ? (1 + (ArgumentCounter++) % 9).ToString() : string.Empty);
                 formattedArguments = string.Format("{0}:{1}",

--- a/Simple.OData.Client.Dynamic/ODataDynamic.cs
+++ b/Simple.OData.Client.Dynamic/ODataDynamic.cs
@@ -29,7 +29,8 @@ namespace Simple.OData.Client
 
         public static ODataExpression ExpressionFromFunction(string functionName, string targetName, IEnumerable<object> arguments)
         {
-            return DynamicODataExpression.FromFunction(functionName, targetName, arguments);
+            var targetExpression = DynamicODataExpression.FromReference(targetName);
+            return DynamicODataExpression.FromFunction(functionName, targetExpression, arguments);
         }
     }
 }


### PR DESCRIPTION
#355 Added support of the filter function any() to be used without parameters.

#356 Corrected the creation of FunctionExpression in ExpressionFromFunction.
Before calling DynamicODataExpression.FromFunction(), a refrence Expression must be created from the  targetName. Otherwise it will be implicitly casted to a value Expression. (Which then fails in ODataExpression.FormatCallerReference())
