### PR TITLE
Commit ExecuteAsArrayAsync Properties Support

### DIFF
--- a/CommonAssemblyVersion.cs
+++ b/CommonAssemblyVersion.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
-[assembly: AssemblyInformationalVersion("5.0.0.0")]
+[assembly: AssemblyVersion("5.0.0.1")]
+[assembly: AssemblyFileVersion("5.0.0.1")]
+[assembly: AssemblyInformationalVersion("5.0.0.1")]

--- a/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
+++ b/Simple.OData.Client.Core/Fluent/FluentClientBase.cs
@@ -12,7 +12,7 @@ namespace Simple.OData.Client
     /// Provides access to OData operations in a fluent style.
     /// </summary>
     /// <typeparam name="T">The entity type.</typeparam>
-    public abstract partial class FluentClientBase<T, FT> : IFluentClient<T, FT> 
+    public abstract partial class FluentClientBase<T, FT> : IFluentClient<T, FT>
         where T : class
         where FT : class
     {
@@ -24,7 +24,7 @@ namespace Simple.OData.Client
         protected FluentCommand _command;
         protected readonly bool _dynamicResults;
 
-        internal FluentClientBase(ODataClient client, Session session, 
+        internal FluentClientBase(ODataClient client, Session session,
             FluentCommand parentCommand = null, FluentCommand command = null, bool dynamicResults = false)
         {
             _client = client;
@@ -561,14 +561,16 @@ namespace Simple.OData.Client
         {
             return ExecuteAsArrayAsync<U>(CancellationToken.None);
         }
+
         /// <summary>
         /// Executes the OData function and returns an array.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="dynamicPropertiesContainerName">the name of dynamicPropertiesContainer</param>
         /// <returns>Execution result.</returns>
-        public Task<U[]> ExecuteAsArrayAsync<U>(CancellationToken cancellationToken)
+        public Task<U[]> ExecuteAsArrayAsync<U>(CancellationToken cancellationToken, string dynamicPropertiesContainerName = null)
         {
-            return _client.ExecuteAsArrayAsync<U>(_command, cancellationToken);
+            return _client.ExecuteAsArrayAsync<U>(_command, cancellationToken, dynamicPropertiesContainerName);
         }
 
         /// <summary>

--- a/Simple.OData.Client.Core/Fluent/IFluentClient.cs
+++ b/Simple.OData.Client.Core/Fluent/IFluentClient.cs
@@ -10,7 +10,7 @@ namespace Simple.OData.Client
     /// Provides access to OData operations in a fluent style.
     /// </summary>
     /// <typeparam name="T">The entity type.</typeparam>
-    public interface IFluentClient<T,FT>
+    public interface IFluentClient<T, FT>
         where T : class
     {
         /// <summary>
@@ -435,13 +435,15 @@ namespace Simple.OData.Client
         /// <typeparam name="U">The type of the result array.</typeparam>
         /// <returns>Execution result.</returns>
         Task<U[]> ExecuteAsArrayAsync<U>();
+
         /// <summary>
         /// Executes the OData function or action and returns an array.
         /// </summary>
         /// <typeparam name="U">The type of the result array.</typeparam>
         /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="dynamicPropertiesContainerName">the name of dynamicPropertiesContainer</param>
         /// <returns>Action execution result.</returns>
-        Task<U[]> ExecuteAsArrayAsync<U>(CancellationToken cancellationToken);
+        Task<U[]> ExecuteAsArrayAsync<U>(CancellationToken cancellationToken, string dynamicPropertiesContainerName);
 
         /// <summary>
         /// Gets the OData command text.

--- a/Simple.OData.Client.Core/ODataClient.Async.cs
+++ b/Simple.OData.Client.Core/ODataClient.Async.cs
@@ -1186,7 +1186,7 @@ namespace Simple.OData.Client
                 : (T)Utils.Convert(result.First().Value, typeof(T));
         }
 
-        internal async Task<T[]> ExecuteAsArrayAsync<T>(FluentCommand command, CancellationToken cancellationToken)
+        internal async Task<T[]> ExecuteAsArrayAsync<T>(FluentCommand command, CancellationToken cancellationToken, string dynamicPropertiesContainerName)
         {
             if (IsBatchResponse)
                 return _batchResponse.AsArray<T>();
@@ -1198,7 +1198,7 @@ namespace Simple.OData.Client
                 ? null
                 : typeof(T) == typeof(string) || typeof(T).IsValue()
                 ? result.SelectMany(x => x.Values).Select(x => (T)Utils.Convert(x, typeof(T))).ToArray()
-                : result.Select(x => (T)x.ToObject(typeof(T))).ToArray();
+                : result.Select(x => (T)x.ToObject(typeof(T), dynamicPropertiesContainerName)).ToArray();
         }
 
         internal async Task ExecuteBatchAsync(IList<Func<IODataClient, Task>> actions, CancellationToken cancellationToken)

--- a/Solutions/.vs/config/applicationhost.config
+++ b/Solutions/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="Simple.OData.NorthwindService" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Projects\Git\Simple.OData.Client\Simple.OData.NorthwindService" />
+                    <virtualDirectory path="/" physicalPath="C:\Users\cyril\Source\ForeignRepos\Simple.OData.Client\Simple.OData.NorthwindService" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:55172:localhost" />


### PR DESCRIPTION
This is not supported:
(Set dynamicpropertycontainer for Generic Type defined in ExecuteAsArrayAsync)

`return await OdataClient.For<T>(collectionName)
                                     .Function("ModifiedSince")
                                     .Set(new Dictionary<string, object> { { "Date", datestring } }).ExecuteAsArrayAsync<EntityDiffDto>(CancellationToken.None) ==> .WithProperties(a=>a.ChangedProperties); <==

I modified the code to allow this in this way (optional argument)

            return await OdataClient
             .For<T>(collectionName)
             .Function("ModifiedSince")
             .Set(new Dictionary<string, object> { { "Date", datestring } }).ExecuteAsArrayAsync<EntityDiffDto>(CancellationToken.None, **nameof(EntityDiffDto.ChangedProperties)**);