### PR TITLE
Make EF use localdb rather than SqlExpress

### DIFF
--- a/ActionProviderImplementation/App.config
+++ b/ActionProviderImplementation/App.config
@@ -5,7 +5,11 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 --></configSections>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+      <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+          <parameters>
+              <parameter value="v11.0" />
+          </parameters>
+      </defaultConnectionFactory>
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>

--- a/Simple.OData.Client.Tests.Net40/App.config
+++ b/Simple.OData.Client.Tests.Net40/App.config
@@ -40,7 +40,11 @@
     </assemblyBinding>
   </runtime>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="v11.0" />
+      </parameters>
+    </defaultConnectionFactory>
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>

--- a/Simple.OData.Client.Tests.Net45/App.config
+++ b/Simple.OData.Client.Tests.Net45/App.config
@@ -32,7 +32,11 @@
     </assemblyBinding>
   </runtime>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+      <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+          <parameters>
+              <parameter value="v11.0" />
+          </parameters>
+      </defaultConnectionFactory>
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>

--- a/Simple.OData.NorthwindService/Web.config
+++ b/Simple.OData.NorthwindService/Web.config
@@ -5,6 +5,11 @@
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
   </configSections>
   <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="v11.0" />
+      </parameters>
+    </defaultConnectionFactory>
     <!--<providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>-->

--- a/Simple.OData.ProductService/Web.config
+++ b/Simple.OData.ProductService/Web.config
@@ -30,7 +30,11 @@
     </modules>
   </system.webServer>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+      <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+          <parameters>
+              <parameter value="v11.0" />
+          </parameters>
+      </defaultConnectionFactory>
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>

--- a/WebApiOData.V3.Samples/app.config
+++ b/WebApiOData.V3.Samples/app.config
@@ -25,7 +25,11 @@
     </assemblyBinding>
   </runtime>
   <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+      <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+          <parameters>
+              <parameter value="v11.0" />
+          </parameters>
+      </defaultConnectionFactory>
     <providers>
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>


### PR DESCRIPTION
I couldn't run the integration tests as EntityFramework was trying to connect to SqlExpress, which I don't  have installed as I already have full SQL Server,

There is localdb which is installed as part Visual Studio under SQL Data Tools, so I've changed the default connection factory to use that instead