### PR TITLE
Add support for multiple requests when using ODataBatch (helps support xcsrf tokens)

### DIFF
--- a/Simple.OData.Client.Core/ODataBatch.cs
+++ b/Simple.OData.Client.Core/ODataBatch.cs
@@ -50,11 +50,21 @@ namespace Simple.OData.Client
         /// Initializes a new instance of the <see cref="ODataBatch"/> class.
         /// </summary>
         /// <param name="client">The OData client which settings will be used to create a batch.</param>
-        public ODataBatch(IODataClient client)
-        {
-            _client = new ODataClient((client as ODataClient).Session.Settings, _entryMap);
-        }
+        public ODataBatch(IODataClient client) : this(client, false) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ODataBatch"/> class.
+        /// </summary>
+        /// <param name="client">The OData client which will be used to create a batch.</param>
+        /// <param name="reuseSession">Flag indicating that the existing session from the <see cref="ODataClient"/>
+        /// should be used rather than creating a new one.
+        /// </param>
+        public ODataBatch(IODataClient client, bool reuseSession)
+        {
+            _client = reuseSession
+                ? new ODataClient((client as ODataClient), _entryMap) 
+                : new ODataClient((client as ODataClient).Session.Settings, _entryMap);
+        }
         /// <summary>
         /// Adds an OData command to an OData batch.
         /// </summary>

--- a/Simple.OData.Client.Core/ODataClient.cs
+++ b/Simple.OData.Client.Core/ODataClient.cs
@@ -76,7 +76,6 @@ namespace Simple.OData.Client
         }
 
         internal Session Session { get { return _session; } }
-        internal ODataClientSettings Settings { get { return _settings; } }
         internal ODataResponse BatchResponse { get { return _batchResponse; } }
         internal bool IsBatchRequest { get { return _lazyBatchWriter != null; } }
         internal bool IsBatchResponse { get { return _batchResponse != null; } }

--- a/Simple.OData.Client.Core/ODataClient.cs
+++ b/Simple.OData.Client.Core/ODataClient.cs
@@ -57,6 +57,18 @@ namespace Simple.OData.Client
             }
         }
 
+        internal ODataClient(ODataClient client, SimpleDictionary<object, IDictionary<string, object>> batchEntries)
+        {
+            _settings = client._settings;
+            _session = client.Session;
+            _requestRunner = client._requestRunner;
+            if (batchEntries != null)
+            {
+                _batchEntries = batchEntries;
+                _lazyBatchWriter = new Lazy<IBatchWriter>(() => _session.Adapter.GetBatchWriter(_batchEntries));
+            }
+        }
+
         internal ODataClient(ODataClient client, ODataResponse batchResponse)
         {
             _session = client.Session;
@@ -64,6 +76,7 @@ namespace Simple.OData.Client
         }
 
         internal Session Session { get { return _session; } }
+        internal ODataClientSettings Settings { get { return _settings; } }
         internal ODataResponse BatchResponse { get { return _batchResponse; } }
         internal bool IsBatchRequest { get { return _lazyBatchWriter != null; } }
         internal bool IsBatchResponse { get { return _batchResponse != null; } }
@@ -169,6 +182,28 @@ namespace Simple.OData.Client
         public void SetPluralizer(IPluralizer pluralizer)
         {
             _session.Pluralizer = pluralizer;
+        }
+
+        /// <summary>
+        /// Allows callers to manipulate the request headers in between request executions.
+        /// Useful for retrieval of x-csrf-tokens when you want to update the request header
+        /// with the retrieved token on subsequent requests.
+        /// </summary>
+        /// <param name="headers">The list of headers to update.</param>
+        public void UpdateRequestHeaders(Dictionary<string, IEnumerable<string>> headers)
+        {
+            _settings.BeforeRequest += (request) =>
+            {
+                foreach (var header in headers)
+                {
+                    if (request.Headers.Contains(header.Key))
+                    {
+                        request.Headers.Remove(header.Key);
+                    }
+
+                    request.Headers.Add(header.Key, header.Value);
+                }
+            };
         }
     }
 }

--- a/Simple.OData.Client.Tests.Net40/ClientSettingsTests.cs
+++ b/Simple.OData.Client.Tests.Net40/ClientSettingsTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Simple.OData.Client.Tests
+{
+    public class ClientSettingsTests : TestBase
+    {
+        [Fact]
+        public async Task UpdateRequestHeadersForXCsrfTokenRequests()
+        {
+            // Make sure the default doesn't contain any headers
+            var concreteClient = _client as ODataClient;
+            Assert.Null(concreteClient.Settings.BeforeRequest);
+
+            // Add some headers - note this will simply set up the request action
+            // to lazily add them to the request.
+            concreteClient.UpdateRequestHeaders(new Dictionary<string, IEnumerable<string>>
+            {
+                {"x-csrf-token", new List<string> {"fetch"}}
+            });
+            Assert.NotNull(concreteClient.Settings.BeforeRequest);
+            
+            // Make sure we can still execute a request
+            Assert.DoesNotThrow(async () => await concreteClient.GetMetadataDocumentAsync());
+        }
+    }
+}

--- a/Simple.OData.Client.Tests.Net40/ClientSettingsTests.cs
+++ b/Simple.OData.Client.Tests.Net40/ClientSettingsTests.cs
@@ -14,7 +14,7 @@ namespace Simple.OData.Client.Tests
         {
             // Make sure the default doesn't contain any headers
             var concreteClient = _client as ODataClient;
-            Assert.Null(concreteClient.Settings.BeforeRequest);
+            Assert.Null(concreteClient.Session.Settings.BeforeRequest);
 
             // Add some headers - note this will simply set up the request action
             // to lazily add them to the request.
@@ -22,7 +22,7 @@ namespace Simple.OData.Client.Tests
             {
                 {"x-csrf-token", new List<string> {"fetch"}}
             });
-            Assert.NotNull(concreteClient.Settings.BeforeRequest);
+            Assert.NotNull(concreteClient.Session.Settings.BeforeRequest);
             
             // Make sure we can still execute a request
             Assert.DoesNotThrow(async () => await concreteClient.GetMetadataDocumentAsync());

--- a/Simple.OData.Client.Tests.Net40/Simple.OData.Client.Tests.Net40.csproj
+++ b/Simple.OData.Client.Tests.Net40/Simple.OData.Client.Tests.Net40.csproj
@@ -176,6 +176,7 @@
     <Compile Include="ClientAdapterTests.cs" />
     <Compile Include="BatchTests.cs" />
     <Compile Include="ClientReadOnlyTests.cs" />
+    <Compile Include="ClientSettingsTests.cs" />
     <Compile Include="DeleteDynamicTests.cs" />
     <Compile Include="DeleteTypedTests.cs" />
     <Compile Include="DeleteTests.cs" />


### PR DESCRIPTION
A few of these changes felt really clunky to me because of the existing design patterns.  Like I'm trying to shoe horn in my use case to fit into the overall architecture, but I also tried to keep the changes minimal.  Integration/Unit tests are shown as examples more than anything else as they aren't able to hit any endpoints that actually provide xcsrf tokens, but when I tested this code in my specific environment where I'm able to get back tokens, it was working.