### PR TITLE
Reduce $metadata lookups and model parsing

### DIFF
--- a/Simple.OData.Client.Core/Adapter/IODataModelAdapter.cs
+++ b/Simple.OData.Client.Core/Adapter/IODataModelAdapter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+#pragma warning disable 1591
+
+namespace Simple.OData.Client
+{
+    public interface IODataModelAdapter
+    {
+        AdapterVersion AdapterVersion { get; }
+        string ProtocolVersion { get; set; }
+        object Model { get; set;  }
+    }
+}

--- a/Simple.OData.Client.Core/Adapter/ODataModelAdapterBase.cs
+++ b/Simple.OData.Client.Core/Adapter/ODataModelAdapterBase.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#pragma warning disable 1591
+
+namespace Simple.OData.Client
+{
+    public abstract class ODataModelAdapterBase : IODataModelAdapter
+    {
+        public abstract AdapterVersion AdapterVersion { get; }
+
+        public string ProtocolVersion { get; set; }
+ 
+        public object Model { get; set; }
+    }
+}

--- a/Simple.OData.Client.Core/MetadataCache.cs
+++ b/Simple.OData.Client.Core/MetadataCache.cs
@@ -1,18 +1,103 @@
 ﻿using System;
+#if NET40
+using System.Collections.Concurrent;
+#endif
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading.Tasks;
 
 namespace Simple.OData.Client
 {
     class MetadataCache
     {
-        public static readonly SimpleDictionary<string, MetadataCache> Instances = new SimpleDictionary<string, MetadataCache>();
+#if NET40
+        static readonly ConcurrentDictionary<string, MetadataCache> _instances = new ConcurrentDictionary<string, MetadataCache>();
+#else
+        static readonly object metadataLock = new object();
+        static readonly IDictionary<string, MetadataCache> _instances = new Dictionary<string, MetadataCache>();
+#endif
+
+        public static void Clear()
+        {
+#if NET40
+            _instances.Clear();
+#else
+            lock (metadataLock)
+            {
+                _instances.Clear();
+            }
+#endif
+        }
+
+        public static void Clear(string key)
+        {
+#if NET40
+            MetadataCache _ignored;
+            _instances.TryRemove(key, out _ignored);
+#else
+            lock (metadataLock)
+            {
+                _instances.Remove(key);
+            }
+#endif
+        }
+
+        public static MetadataCache GetOrAdd(string key, Func<string, MetadataCache> valueFactory)
+        {
+#if NET40
+            return _instances.GetOrAdd(key, valueFactory);
+#else
+            lock (metadataLock)
+            {
+                MetadataCache found;
+                if (!_instances.TryGetValue(key, out found))
+                {
+                    _instances[key] = found = valueFactory(key);
+                }
+
+                return found;
+            }
+#endif
+        }
+
+        private readonly string _key;
+        private Func<ISession, IODataAdapter> _adapterFactory;
 
         private string _metadataDocument;
+        private Task _resolutionTask;
 
-        public bool IsResolved()
+        public MetadataCache(string key)
         {
-            return _metadataDocument != null;
+            if (String.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException("key");
+
+            _key = key;
+        }
+
+        public MetadataCache(string key, string metadataDocument)
+        {
+            if (String.IsNullOrWhiteSpace(key))
+                throw new ArgumentNullException("key");
+            if (String.IsNullOrWhiteSpace(metadataDocument))
+                throw new ArgumentNullException("metadataDocument");
+
+            _key = key;
+            SetMetadataDocument(metadataDocument);
+
+#if !NET40
+            _resolutionTask = Task.FromResult(metadataDocument);
+#else
+            var tcs = new TaskCompletionSource<string>();
+            tcs.SetResult(metadataDocument);
+            _resolutionTask = tcs.Task;
+#endif
+        }
+
+        public string Key
+        {
+            get
+            {
+                return _key;
+            }
         }
 
         public string MetadataDocument
@@ -26,9 +111,28 @@ namespace Simple.OData.Client
             }
         }
 
+        public Task Resolved
+        {
+            get
+            {
+                return _resolutionTask;
+            }
+        }
+
+        public void SetMetadataDocument(Task<string> metadataResolution)
+        {
+            _resolutionTask = metadataResolution.ContinueWith(t => SetMetadataDocument(t.Result));
+        }
+
         public void SetMetadataDocument(string metadataString)
         {
             _metadataDocument = metadataString;
+            _adapterFactory = new AdapterFactory().CreateAdapter(metadataString);
+        }
+
+        public IODataAdapter GetODataAdapter(ISession session)
+        {
+            return _adapterFactory(session);
         }
     }
 }

--- a/Simple.OData.Client.Core/ODataClient.cs
+++ b/Simple.OData.Client.Core/ODataClient.cs
@@ -100,10 +100,7 @@ namespace Simple.OData.Client
         /// </summary>
         public static void ClearMetadataCache()
         {
-            lock (MetadataCache.Instances)
-            {
-                MetadataCache.Instances.Clear();
-            }
+            MetadataCache.Clear();
         }
 
         /// <summary>

--- a/Simple.OData.Client.Core/Simple.OData.Client.Core.csproj
+++ b/Simple.OData.Client.Core/Simple.OData.Client.Core.csproj
@@ -51,7 +51,9 @@
     <Compile Include="Adapter\FunctionFormat.cs" />
     <Compile Include="Adapter\ICommandFormatter.cs" />
     <Compile Include="Adapter\IODataAdapter.cs" />
+    <Compile Include="Adapter\IODataModelAdapter.cs" />
     <Compile Include="Adapter\MetadataBase.cs" />
+    <Compile Include="Adapter\ODataModelAdapterBase.cs" />
     <Compile Include="Adapter\RequestWriterBase.cs" />
     <Compile Include="Adapter\ResponseNode.cs" />
     <Compile Include="Adapter\ResponseReaderBase.cs" />

--- a/Simple.OData.Client.IntegrationTests/FindNuGetTests.cs
+++ b/Simple.OData.Client.IntegrationTests/FindNuGetTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -65,21 +64,21 @@ namespace Simple.OData.Client.Tests
         [Fact]
         public async Task FindEntryNuGetV2MultiThreadWithDelays()
         {
+            int taskCount = 100;
             Random random = new Random();
             MetadataCache.Clear();
 
             var tasks = new List<Task>();
             metadataCalls = 0;
-
-            for (var i = 0; i < 100; i++)
+            
+            for (var i = 0; i < taskCount; i++)
             {
-                tasks.Add(
-                    Task.Run(async () =>
-                    {
-                        await Task.Delay(random.Next(1, 50));
+                if (random.NextDouble() < 0.25)
+                {
+                    await Task.Delay(random.Next(1, 250));
+                }
 
-                        await FindEntryNuGetV2();
-                    }));
+                tasks.Add(FindEntryNuGetV2());
             }
 
             await Task.WhenAll(tasks);

--- a/Simple.OData.Client.IntegrationTests/FindNuGetTests.cs
+++ b/Simple.OData.Client.IntegrationTests/FindNuGetTests.cs
@@ -1,10 +1,16 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Simple.OData.Client.Tests
 {
     public class FindNuGetTests
     {
+        private int metadataCalls;
+
         [Fact]
         public async Task FindEntryNuGetV1()
         {
@@ -17,9 +23,68 @@ namespace Simple.OData.Client.Tests
         [Fact]
         public async Task FindEntryNuGetV2()
         {
-            var client = new ODataClient("http://nuget.org/api/v2");
+            var settings = new ODataClientSettings("http://nuget.org/api/v2")
+            {
+                OnTrace = (format, args) =>
+                {
+                    if (args.Length > 1)
+                    {
+                        var request = args[1] as string;
+                        if (request != null && request.EndsWith("$metadata"))
+                        {
+                            Interlocked.Increment(ref metadataCalls);
+                        }
+                    }
+                    var msg = string.Format(format, args);
+                    Console.WriteLine($"[{DateTimeOffset.Now:O}][OData] " + msg);
+                }
+            };
+            var client = new ODataClient(settings);
             var package = await client.FindEntryAsync("Packages?$filter=Title eq 'EntityFramework'");
             Assert.NotNull(package["Id"]);
+        }
+
+        [Fact]
+        public async Task FindEntryNuGetV2MultiThread()
+        {
+            MetadataCache.Clear();
+
+            var tasks = new List<Task>();
+            metadataCalls = 0;
+
+            for (var i = 0; i < 10; i++)
+            {
+                tasks.Add(FindEntryNuGetV2());
+            }
+
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(1, metadataCalls);
+        }
+
+        [Fact]
+        public async Task FindEntryNuGetV2MultiThreadWithDelays()
+        {
+            Random random = new Random();
+            MetadataCache.Clear();
+
+            var tasks = new List<Task>();
+            metadataCalls = 0;
+
+            for (var i = 0; i < 100; i++)
+            {
+                tasks.Add(
+                    Task.Run(async () =>
+                    {
+                        await Task.Delay(random.Next(1, 50));
+
+                        await FindEntryNuGetV2();
+                    }));
+            }
+
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(1, metadataCalls);
         }
 
         [Fact]

--- a/Simple.OData.Client.Net40/Simple.OData.Client.Net40.csproj
+++ b/Simple.OData.Client.Net40/Simple.OData.Client.Net40.csproj
@@ -144,6 +144,9 @@
     <Compile Include="..\Simple.OData.Client.Core\Adapter\IODataAdapter.cs">
       <Link>Adapter\IODataAdapter.cs</Link>
     </Compile>
+    <Compile Include="..\Simple.OData.Client.Core\Adapter\IODataModelAdapter.cs">
+      <Link>Adapter\IODataModelAdapter.cs</Link>
+    </Compile>
     <Compile Include="..\Simple.OData.Client.Core\Adapter\IRequestWriter.cs">
       <Link>Adapter\IRequestWriter.cs</Link>
     </Compile>
@@ -155,6 +158,9 @@
     </Compile>
     <Compile Include="..\Simple.OData.Client.Core\Adapter\ODataAdapterBase.cs">
       <Link>Adapter\ODataAdapterBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Simple.OData.Client.Core\Adapter\ODataModelAdapterBase.cs">
+      <Link>Adapter\ODataModelAdapterBase.cs</Link>
     </Compile>
     <Compile Include="..\Simple.OData.Client.Core\Adapter\RequestWriterBase.cs">
       <Link>Adapter\RequestWriterBase.cs</Link>
@@ -372,6 +378,9 @@
     <Compile Include="..\Simple.OData.Client.V3.Adapter\ODataAdapter.cs">
       <Link>AdapterV3\ODataAdapter.cs</Link>
     </Compile>
+    <Compile Include="..\Simple.OData.Client.V3.Adapter\ODataModelAdapter.cs">
+      <Link>AdapterV3\ODataModelAdapter.cs</Link>
+    </Compile>
     <Compile Include="..\Simple.OData.Client.V3.Adapter\ODataRequestMessage.cs">
       <Link>AdapterV3\ODataRequestMessage.cs</Link>
     </Compile>
@@ -401,6 +410,9 @@
     </Compile>
     <Compile Include="..\Simple.OData.Client.V4.Adapter\ODataAdapter.cs">
       <Link>AdapterV4\ODataAdapter.cs</Link>
+    </Compile>
+    <Compile Include="..\Simple.OData.Client.V4.Adapter\ODataModelAdapter.cs">
+      <Link>AdapterV4\ODataModelAdapter.cs</Link>
     </Compile>
     <Compile Include="..\Simple.OData.Client.V4.Adapter\ODataRequestMessage.cs">
       <Link>AdapterV4\ODataRequestMessage.cs</Link>

--- a/Simple.OData.Client.V3.Adapter/ODataAdapter.cs
+++ b/Simple.OData.Client.V3.Adapter/ODataAdapter.cs
@@ -42,34 +42,14 @@ namespace Simple.OData.Client.V3.Adapter
             set { base.Model = value; }
         }
 
-        private ODataAdapter(ISession session, string protocolVersion)
+        public ODataAdapter(ISession session, IODataModelAdapter modelAdapter)
         {
             _session = session;
-            ProtocolVersion = protocolVersion;
+            ProtocolVersion = modelAdapter.ProtocolVersion;
+            Model = modelAdapter.Model as IEdmModel;
 
             CustomConverters.RegisterTypeConverter(typeof(GeographyPoint), TypeConverters.CreateGeographyPoint);
             CustomConverters.RegisterTypeConverter(typeof(GeometryPoint), TypeConverters.CreateGeometryPoint);
-        }
-
-        public ODataAdapter(ISession session, string protocolVersion, HttpResponseMessage response)
-            : this(session, protocolVersion)
-        {
-            var readerSettings = new ODataMessageReaderSettings
-            {
-                MessageQuotas = { MaxReceivedMessageSize = Int32.MaxValue }
-            };
-            using (var messageReader = new ODataMessageReader(new ODataResponseMessage(response), readerSettings))
-            {
-                Model = messageReader.ReadMetadataDocument();
-            }
-        }
-
-        public ODataAdapter(ISession session, string protocolVersion, string metadataString)
-            : this(session, protocolVersion)
-        {
-            var reader = XmlReader.Create(new StringReader(metadataString));
-            reader.MoveToContent();
-            Model = EdmxReader.Parse(reader);
         }
 
         public override string GetODataVersionString()

--- a/Simple.OData.Client.V3.Adapter/ODataModelAdapter.cs
+++ b/Simple.OData.Client.V3.Adapter/ODataModelAdapter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Spatial;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.Data.Edm;
+using Microsoft.Data.Edm.Csdl;
+using Microsoft.Data.OData;
+
+#pragma warning disable 1591
+
+namespace Simple.OData.Client
+{
+    public static class V3ModelAdapter
+    {
+        public static void Reference() { }
+    }
+}
+
+#pragma warning disable 1591
+
+namespace Simple.OData.Client.V3.Adapter
+{
+    public class ODataModelAdapter : ODataModelAdapterBase
+    {
+        public override AdapterVersion AdapterVersion { get { return AdapterVersion.V3; } }
+
+        public new IEdmModel Model
+        {
+            get { return base.Model as IEdmModel; }
+            set { base.Model = value; }
+        }
+
+        private ODataModelAdapter(string protocolVersion)
+        {
+            ProtocolVersion = protocolVersion;
+        }
+
+        public ODataModelAdapter(string protocolVersion, HttpResponseMessage response)
+            : this(protocolVersion)
+        {
+            var readerSettings = new ODataMessageReaderSettings
+            {
+                MessageQuotas = { MaxReceivedMessageSize = Int32.MaxValue }
+            };
+            using (var messageReader = new ODataMessageReader(new ODataResponseMessage(response), readerSettings))
+            {
+                Model = messageReader.ReadMetadataDocument();
+            }
+        }
+
+        public ODataModelAdapter(string protocolVersion, string metadataString)
+            : this(protocolVersion)
+        {
+            using (var reader = XmlReader.Create(new StringReader(metadataString)))
+            {
+                reader.MoveToContent();
+                Model = EdmxReader.Parse(reader);
+            }
+        }
+    }
+}

--- a/Simple.OData.Client.V3.Adapter/Simple.OData.Client.V3.Adapter.csproj
+++ b/Simple.OData.Client.V3.Adapter/Simple.OData.Client.V3.Adapter.csproj
@@ -53,6 +53,7 @@
     <Compile Include="EdmDeltaModel.cs" />
     <Compile Include="Metadata.cs" />
     <Compile Include="ODataAdapter.cs" />
+    <Compile Include="ODataModelAdapter.cs" />
     <Compile Include="ODataRequestMessage.cs" />
     <Compile Include="ODataResponseMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Simple.OData.Client.V4.Adapter/ODataAdapter.cs
+++ b/Simple.OData.Client.V4.Adapter/ODataAdapter.cs
@@ -21,6 +21,8 @@ namespace Simple.OData.Client
     }
 }
 
+#pragma warning disable 1591
+
 namespace Simple.OData.Client.V4.Adapter
 {
     public class ODataAdapter : ODataAdapterBase
@@ -40,34 +42,14 @@ namespace Simple.OData.Client.V4.Adapter
             set { base.Model = value; }
         }
 
-        private ODataAdapter(ISession session, string protocolVersion)
+        public ODataAdapter(ISession session, IODataModelAdapter modelAdapter)
         {
             _session = session;
-            ProtocolVersion = protocolVersion;
+            ProtocolVersion = modelAdapter.ProtocolVersion;
+            Model = modelAdapter.Model as IEdmModel;
 
             CustomConverters.RegisterTypeConverter(typeof(GeographyPoint), TypeConverters.CreateGeographyPoint);
             CustomConverters.RegisterTypeConverter(typeof(GeometryPoint), TypeConverters.CreateGeometryPoint);
-        }
-
-        public ODataAdapter(ISession session, string protocolVersion, HttpResponseMessage response)
-            : this(session, protocolVersion)
-        {
-            var readerSettings = new ODataMessageReaderSettings
-            {
-                MessageQuotas = { MaxReceivedMessageSize = Int32.MaxValue }
-            };
-            using (var messageReader = new ODataMessageReader(new ODataResponseMessage(response), readerSettings))
-            {
-                Model = messageReader.ReadMetadataDocument();
-            }
-        }
-
-        public ODataAdapter(ISession session, string protocolVersion, string metadataString)
-            : this(session, protocolVersion)
-        {
-            var reader = XmlReader.Create(new StringReader(metadataString));
-            reader.MoveToContent();
-            Model = EdmxReader.Parse(reader);
         }
 
         public override string GetODataVersionString()

--- a/Simple.OData.Client.V4.Adapter/ODataModelAdapter.cs
+++ b/Simple.OData.Client.V4.Adapter/ODataModelAdapter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.OData.Core;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.Spatial;
+
+#pragma warning disable 1591
+
+namespace Simple.OData.Client
+{
+    public static class V4ModelAdapter
+    {
+        public static void Reference() { }
+    }
+}
+
+#pragma warning disable 1591
+
+namespace Simple.OData.Client.V4.Adapter
+{
+    public class ODataModelAdapter : ODataModelAdapterBase
+    {
+        public override AdapterVersion AdapterVersion { get { return AdapterVersion.V4; } }
+
+        public new IEdmModel Model
+        {
+            get { return base.Model as IEdmModel; }
+            set { base.Model = value; }
+        }
+
+        private ODataModelAdapter(string protocolVersion)
+        {
+            ProtocolVersion = protocolVersion;
+        }
+
+        public ODataModelAdapter(string protocolVersion, HttpResponseMessage response)
+            : this(protocolVersion)
+        {
+            var readerSettings = new ODataMessageReaderSettings
+            {
+                MessageQuotas = { MaxReceivedMessageSize = Int32.MaxValue }
+            };
+            using (var messageReader = new ODataMessageReader(new ODataResponseMessage(response), readerSettings))
+            {
+                Model = messageReader.ReadMetadataDocument();
+            }
+        }
+
+        public ODataModelAdapter(string protocolVersion, string metadataString)
+            : this(protocolVersion)
+        {
+            using (var reader = XmlReader.Create(new StringReader(metadataString)))
+            {
+                reader.MoveToContent();
+                Model = EdmxReader.Parse(reader);
+            }
+        }
+    }
+}

--- a/Simple.OData.Client.V4.Adapter/Simple.OData.Client.V4.Adapter.csproj
+++ b/Simple.OData.Client.V4.Adapter/Simple.OData.Client.V4.Adapter.csproj
@@ -53,6 +53,7 @@
     <Compile Include="EdmDeltaModel.cs" />
     <Compile Include="Metadata.cs" />
     <Compile Include="ODataAdapter.cs" />
+    <Compile Include="ODataModelAdapter.cs" />
     <Compile Include="ODataRequestMessage.cs" />
     <Compile Include="ODataResponseMessage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This PR attempts to address #249 by serializing access to the `$metadata` route per base URI. It also adds a layer of indirection for model parsing, sitting on top of the existing `IODataAdapter` layer.

Basic design:

- `MetadataCache` maintains a static internal, threadsafe dictionary of its own instances, keyed by their AbsoluteURI
- `Session` reaches into `MetadataCache` during construction if given the metadata as a string, otherwise the resolution of the metadata is deferred
- `Session` initiates the metadata resolution, and via the threadsafe `MetadataCache.GetOrAdd` method, it serializes the requests against any `$metadata` route.
- Until the initial request completes, all other requests wait.
- Once the `$metadata` request completes, the `MetadataCache` instance creates an `IODataModelAdapter` (parsing the model) and stores a factory method to create an `IODataAdapter` from an `ISession`
- All of the `Session` instances waiting on the completed metadata request now receive the go-ahead (i.e. "`await MetadataCache.Resolved;`" completes), and they create their adapter using the factory stored in the cache.
- The `IODataAdapter` instance takes the session instance and binds it to the model as before, however, it now receives the model instance from the `IODataModelAdapter`.

In effect this does two things:

1. Metadata is only ever requested once per absolute URI.
2. Metadata is only ever parsed once per absolute URI.

There are some downsides:

- If a metadata request fails, it is not retried and all requests similarly fail.
- The initial session requesting metadata controls the cancellation token.
- If metadata is mutable--I don't know if this is possible--any mutations are shared.