### PR TITLE
Fix for OData 7.x quoting string dynamic type values

### DIFF
--- a/Simple.OData.Client.V4.Adapter/ResponseReader.cs
+++ b/Simple.OData.Client.V4.Adapter/ResponseReader.cs
@@ -271,7 +271,7 @@ namespace Simple.OData.Client.V4.Adapter
                     // Don't just replace \" in case we have embedded quotes
                     if (result.StartsWith("\"") && result.EndsWith("\""))
                     {
-                        result = result.Substring(1, result.Length - 1);
+                        result = result.Substring(1, result.Length - 2);
                     }
                 }
                 return result;

--- a/Simple.OData.Client.V4.Adapter/ResponseReader.cs
+++ b/Simple.OData.Client.V4.Adapter/ResponseReader.cs
@@ -269,13 +269,9 @@ namespace Simple.OData.Client.V4.Adapter
                 {
                     // Remove extra quoting as has been read as a string
                     // Don't just replace \" in case we have embedded quotes
-                    if (result.StartsWith("\""))
+                    if (result.StartsWith("\"") && result.EndsWith("\""))
                     {
-                        result = result.Substring(1);
-                    }
-                    if (result.EndsWith("\""))
-                    {
-                        result = result.Substring(0, result.Length - 1);
+                        result = result.Substring(1, result.Length - 1);
                     }
                 }
                 return result;

--- a/Simple.OData.Client.V4.Adapter/ResponseReader.cs
+++ b/Simple.OData.Client.V4.Adapter/ResponseReader.cs
@@ -250,23 +250,35 @@ namespace Simple.OData.Client.V4.Adapter
 
         private object GetPropertyValue(object value)
         {
-            if (value is ODataResource)
+            if (value is ODataResource resource)
             {
-                return ((ODataResource) value).Properties.ToDictionary(
-                    x => x.Name, x => GetPropertyValue(x.Value));
+                return resource.Properties.ToDictionary(x => x.Name, x => GetPropertyValue(x.Value));
             }
-            else if (value is ODataCollectionValue)
+            else if (value is ODataCollectionValue collectionValue)
             {
-                return ((ODataCollectionValue) value).Items
-                    .Select(GetPropertyValue).ToList();
+                return collectionValue.Items.Select(GetPropertyValue).ToList();
             }
-            else if (value is ODataEnumValue)
+            else if (value is ODataEnumValue enumValue)
             {
-                return ((ODataEnumValue) value).Value;
+                return enumValue.Value;
             }
-            else if (value is ODataUntypedValue)
+            else if (value is ODataUntypedValue untypedValue)
             {
-                return ((ODataUntypedValue) value).RawValue;
+                var result = untypedValue.RawValue;
+                if (!string.IsNullOrEmpty(result))
+                {
+                    // Remove extra quoting as has been read as a string
+                    // Don't just replace \" in case we have embedded quotes
+                    if (result.StartsWith("\""))
+                    {
+                        result = result.Substring(1);
+                    }
+                    if (result.EndsWith("\""))
+                    {
+                        result = result.Substring(0, result.Length - 1);
+                    }
+                }
+                return result;
             }
             else if (value is ODataStreamReferenceValue referenceValue)
             {


### PR DESCRIPTION
Strip double quoting of strings for dynamic properties