### PR TITLE
fix Metadata cache for not reused settings

### DIFF
--- a/src/Simple.OData.Client.Core/MetadataCache.cs
+++ b/src/Simple.OData.Client.Core/MetadataCache.cs
@@ -48,7 +48,7 @@ namespace Simple.OData.Client
                 if (_instances.TryGetValue(key, out found))
                     return found;
             }
-            found = await valueFactory(key);
+            found = await valueFactory(key).ConfigureAwait(false);
             lock(metadataLock)
             {
                 if (!_instances.ContainsKey(key))

--- a/src/Simple.OData.Client.Core/MetadataCache.cs
+++ b/src/Simple.OData.Client.Core/MetadataCache.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Simple.OData.Client
 {
@@ -35,6 +37,23 @@ namespace Simple.OData.Client
                 }
 
                 return found;
+            }
+        }
+
+        public static async Task<MetadataCache> GetOrAddAsync(string key, Func<string, Task<MetadataCache>> valueFactory)
+        {
+            MetadataCache found;
+            lock (metadataLock)
+            {
+                if (_instances.TryGetValue(key, out found))
+                    return found;
+            }
+            found = await valueFactory(key);
+            lock(metadataLock)
+            {
+                if (!_instances.ContainsKey(key))
+                    _instances[key] = found;
+                return _instances[key];
             }
         }
 

--- a/src/Simple.OData.Client.Core/Session.cs
+++ b/src/Simple.OData.Client.Core/Session.cs
@@ -71,7 +71,7 @@ namespace Simple.OData.Client
                         this.Settings.BaseUri.AbsoluteUri,
                         async uri =>
                         {
-                            var metadata = await ResolveMetadataAsync(cancellationToken);
+                            var metadata = await ResolveMetadataAsync(cancellationToken).ConfigureAwait(false);
                             return new MetadataCache(uri, metadata);
                         });
                 }

--- a/src/Simple.OData.Client.Core/Session.cs
+++ b/src/Simple.OData.Client.Core/Session.cs
@@ -65,19 +65,27 @@ namespace Simple.OData.Client
         {
             if (this.MetadataCache == null)
             {
-                string metadataDocument = Settings.MetadataDocument;
-                if (string.IsNullOrEmpty(metadataDocument))
+                if (string.IsNullOrEmpty(Settings.MetadataDocument))
                 {
-                    metadataDocument = await ResolveMetadataAsync(cancellationToken).ConfigureAwait(false);
-                }
-                this.MetadataCache =
-                    MetadataCache.GetOrAdd(
+                    this.MetadataCache = await MetadataCache.GetOrAddAsync(
                         this.Settings.BaseUri.AbsoluteUri,
-                        uri =>
+                        async uri =>
                         {
-                            var cache = new MetadataCache(uri, metadataDocument);
-                            return cache;
+                            var metadata = await ResolveMetadataAsync(cancellationToken);
+                            return new MetadataCache(uri, metadata);
                         });
+                }
+                else
+                {
+                    this.MetadataCache =
+                        MetadataCache.GetOrAdd(
+                            this.Settings.BaseUri.AbsoluteUri,
+                            uri =>
+                            {
+                                var cache = new MetadataCache(uri, Settings.MetadataDocument);
+                                return cache;
+                            });
+                }
             }
 
             if (this.Settings.PayloadFormat == ODataPayloadFormat.Unspecified)

--- a/src/Simple.OData.Client.UnitTests/Core/MetadataCacheTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/MetadataCacheTests.cs
@@ -54,7 +54,7 @@ namespace Simple.OData.Client.Tests.Core
             settings.BeforeRequest = x => throw new Exception("metadata cache was not used");
             await client.GetMetadataAsync();
             
-            settings = new ODataClientSettings{BaseUri = baseUri, BeforeRequest = x=>throw new Exception("not reusing settings with defeat metadata cache")};
+            settings = new ODataClientSettings{BaseUri = baseUri, BeforeRequest = x=>throw new Exception("not reusing settings will defeat metadata cache")};
             client = new ODataClient(settings);
             await client.GetMetadataAsync();
         }

--- a/src/Simple.OData.Client.UnitTests/Core/MetadataCacheTests.cs
+++ b/src/Simple.OData.Client.UnitTests/Core/MetadataCacheTests.cs
@@ -40,5 +40,23 @@ namespace Simple.OData.Client.Tests.Core
             Assert.False(wasCached);
             Assert.Null(cached);
         }
+
+        [Fact]
+        public async Task MetadataIsCached()
+        {
+            var baseUri = new Uri("http://services.odata.org/V3/OData/OData.svc/");
+            var settings = new ODataClientSettings{ BaseUri = baseUri};
+            var client = new ODataClient(settings);
+
+            await client.GetMetadataAsync();
+            MetadataCache.GetOrAdd(baseUri.ToString(), x => throw new Exception("metadata was not cached"));
+
+            settings.BeforeRequest = x => throw new Exception("metadata cache was not used");
+            await client.GetMetadataAsync();
+            
+            settings = new ODataClientSettings{BaseUri = baseUri, BeforeRequest = x=>throw new Exception("not reusing settings with defeat metadata cache")};
+            client = new ODataClient(settings);
+            await client.GetMetadataAsync();
+        }
     }
 }


### PR DESCRIPTION
fixes the bug introduced in #435 as described in #494 

- [x] unit test
- [x] verified reduced $metadata requests in fiddler
- [x] internal review (thx @wiredbarb)
- [ ] maintainer review

Possible issues:
* The test is currently not marked as integration, but is relying on an external odata service.